### PR TITLE
Always use double quotes for strings

### DIFF
--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pip
     - numpy
     - scipy
-    - pyyaml
+    - ruamel_yaml
 
 test:
   requires:

--- a/exdir/core/attribute.py
+++ b/exdir/core/attribute.py
@@ -1,5 +1,5 @@
 from enum import Enum
-import yaml
+import ruamel_yaml as yaml
 import os
 import numpy as np
 import exdir

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -107,7 +107,7 @@ def root_directory(path):
 
         meta_filename = path / META_FILENAME
         with meta_filename.open("r", encoding="utf-8") as meta_file:
-            meta_data = yaml.load(meta_file)
+            meta_data = yaml.safe_load(meta_file)
         if EXDIR_METANAME not in meta_data:
             path = path.parent
             continue

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -1,6 +1,6 @@
 from enum import Enum
 import os
-import yaml
+import ruamel_yaml as yaml
 import warnings
 import pathlib
 from . import filename_validation

--- a/exdir/core/group.py
+++ b/exdir/core/group.py
@@ -1,6 +1,6 @@
 import os
 import re
-import yaml
+import ruamel_yaml as yaml
 import pathlib
 import numpy as np
 import exdir

--- a/exdir/plugins/numpy_attributes.py
+++ b/exdir/plugins/numpy_attributes.py
@@ -1,7 +1,6 @@
 import exdir
 import quantities as pq
 import numpy as np
-import yaml
 
 
 def convert_from_list(data):

--- a/exdir/plugins/quantities.py
+++ b/exdir/plugins/quantities.py
@@ -1,7 +1,6 @@
 import exdir
 import quantities as pq
 import numpy as np
-import yaml
 
 
 def convert_back_quantities(value):

--- a/tests/test_attr.py
+++ b/tests/test_attr.py
@@ -12,7 +12,7 @@
 
 import pytest
 import numpy as np
-import yaml
+import ruamel_yaml as yaml
 
 from exdir.core import Attribute, File
 import six

--- a/tests/test_help_functions.py
+++ b/tests/test_help_functions.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
 import six
-import yaml
+import ruamel_yaml as yaml
 import quantities as pq
 import numpy as np
 import pytest

--- a/tests/test_numpy_attributes.py
+++ b/tests/test_numpy_attributes.py
@@ -24,7 +24,7 @@ def test_with_quantities(setup_teardown_folder):
     f.close()
 
     with open(setup_teardown_folder[1] / "attributes.yaml", "r")  as f:
-        content = "array:\n  unit: m\n  value:\n  - 1.0\n  - 2.0\n  - 3.0\n"
+        content = 'array:\n  value:\n  - 1.0\n  - 2.0\n  - 3.0\n  unit: "m"\n'
         assert content == f.read()
 
 
@@ -34,5 +34,5 @@ def test_with_quantities_reverse_order(setup_teardown_folder):
     f.close()
 
     with open(setup_teardown_folder[1] / "attributes.yaml", "r")  as f:
-        content = "array:\n  unit: m\n  value:\n  - 1.0\n  - 2.0\n  - 3.0\n"
+        content = 'array:\n  value:\n  - 1.0\n  - 2.0\n  - 3.0\n  unit: "m"\n'
         assert content == f.read()

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -12,7 +12,7 @@
 
 import pytest
 import os
-import yaml
+import ruamel_yaml as yaml
 import pathlib
 import exdir
 


### PR DESCRIPTION
This is according to the updated Exdir specification and removes any
ambiguity about which values are implicitly converted to strings and
not.