### PR TITLE
h5py like imports

### DIFF
--- a/exdir/__init__.py
+++ b/exdir/__init__.py
@@ -1,7 +1,7 @@
 from . import core
 from . import plugin_interface
 from . import plugins
-from .core import File, validation
+from .core import File, validation, Attribute, Dataset, Group, Raw, Object
 
 # TODO remove versioneer
 from ._version import get_versions


### PR DESCRIPTION
Should we have h5py like imports? In h5py one can write

    import h5py
    h5py.Dataset

while in exdir one has to write

    import exdir
    exdir.core.Dataset

or:

    import exdir.core as exdir
    exdir.Dataset

Should we choose a solution that is similar to h5py, or should we keep core as a useful warning that you probably should know what you are doing and recommend using `import exdir.core as exdir` when converting from h5py to exdir?


