### PR TITLE
replace ruamel_yaml by ruamel.yaml

### DIFF
--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - setuptools
     - numpy
     - scipy
-    - ruamel_yaml
+    - ruamel.yaml
     - pyyaml
 
 test:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,4 +6,4 @@ dependencies:
   - setuptools
   - numpy
   - scipy
-  - ruamel_yaml
+  - ruamel.yaml

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - numpy
     - scipy
     - pyyaml
-    - ruamel_yaml
+    - ruamel.yaml
     - pytest
     - pytest-benchmark
     - h5py

--- a/exdir/core/attribute.py
+++ b/exdir/core/attribute.py
@@ -1,5 +1,5 @@
 from enum import Enum
-import ruamel_yaml as yaml
+import ruamel.yaml as yaml
 import os
 import numpy as np
 import exdir

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -1,6 +1,6 @@
 from enum import Enum
 import os
-import ruamel_yaml as yaml
+import ruamel.yaml as yaml
 import warnings
 import pathlib
 from . import validation

--- a/exdir/core/group.py
+++ b/exdir/core/group.py
@@ -1,6 +1,6 @@
 import os
 import re
-import ruamel_yaml as yaml
+import ruamel.yaml as yaml
 import pathlib
 import numpy as np
 import exdir

--- a/tests/test_attr.py
+++ b/tests/test_attr.py
@@ -12,7 +12,7 @@
 
 import pytest
 import numpy as np
-import ruamel_yaml as yaml
+import ruamel.yaml as yaml
 
 from exdir.core import Attribute, File
 import six

--- a/tests/test_help_functions.py
+++ b/tests/test_help_functions.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
 import six
-import ruamel_yaml as yaml
+import ruamel.yaml as yaml
 import quantities as pq
 import numpy as np
 import pytest

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -12,7 +12,7 @@
 
 import pytest
 import os
-import ruamel_yaml as yaml
+import ruamel.yaml as yaml
 import pathlib
 import exdir
 


### PR DESCRIPTION
Exdir installed, but could not be imported until `import ruamel_yaml`was substitutded by `ruamel.yaml`.  MacOS 10.13, python 3.6.4.  The travis build of this fork hangs on anaconda cloud deployment, which I guess is a good thing. 