### PR TITLE
Add function to display Exdir objects as a collapsible tree in Jupyter

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include versioneer.py
 include exdir/_version.py
+recursive-include jupyter-config *.json
+recursive-include exdir/static *.js

--- a/exdir/__init__.py
+++ b/exdir/__init__.py
@@ -8,4 +8,22 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
-# core.plugin.load_plugins()
+# Jupyter extensions
+def _jupyter_server_extension_paths():
+    return [{
+        "module": "exdir"
+    }]
+
+# Jupyter Extension points
+def _jupyter_nbextension_paths():
+    return [dict(
+        section="notebook",
+        # the path is relative to the `exdir` directory
+        src="static",
+        # directory in the `nbextension/` namespace
+        dest="exdir",
+        # _also_ in the `nbextension/` namespace
+        require="exdir/index")]
+
+def load_jupyter_server_extension(nbapp):
+    nbapp.log.info("Exdir extension enabled!")

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -7,8 +7,11 @@ import os
 import ruamel_yaml as yaml
 import warnings
 import pathlib
-from . import validation
 
+import exdir
+
+from . import validation
+from . import exdir_object
 from .. import utils
 from .attribute import Attribute
 from .constants import *
@@ -295,3 +298,6 @@ class Object(object):
             self.relative_path == other.relative_path and
             self.root_directory == other.root_directory
         )
+
+    def _repr_html_(self):
+        return exdir.utils.display.html_tree(self)

--- a/exdir/static/index.js
+++ b/exdir/static/index.js
@@ -1,0 +1,107 @@
+/*
+CollapsibleLists.js
+
+An object allowing lists to dynamically expand and collapse
+
+Created by Kate Morley - http://code.iamkate.com/ - and released under the terms
+of the CC0 1.0 Universal legal code:
+
+http://creativecommons.org/publicdomain/zero/1.0/legalcode
+
+Modifications by Svenn-Arne Dragly.
+*/
+
+const exdir = (function() { // namespace
+const CollapsibleLists = (function(){
+
+    // Makes all lists with the class 'collapsibleList' collapsible. The
+    // parameter is:
+    //
+    // doNotRecurse - true if sub-lists should not be made collapsible
+    function apply(doNotRecurse){
+        [].forEach.call(document.getElementsByTagName('ul'), node => {
+            if (node.classList.contains('collapsibleList')){
+                applyTo(node, true);
+                if (!doNotRecurse){
+                    [].forEach.call(node.getElementsByTagName('ul'), subnode => {
+                        subnode.classList.add('collapsibleList')
+                    });
+                }
+            }
+        })
+    }
+
+    // Makes the specified list collapsible. The parameters are:
+    //
+    // node         - the list element
+    // doNotRecurse - true if sub-lists should not be made collapsible
+    function applyTo(node, doNotRecurse){
+        [].forEach.call(node.getElementsByTagName('li'), li => {
+            if (!doNotRecurse || node === li.parentNode){
+                li.style.userSelect       = 'none';
+                li.style.MozUserSelect    = 'none';
+                li.style.msUserSelect     = 'none';
+                li.style.WebkitUserSelect = 'none';
+
+                li.addEventListener('click', handleClick.bind(null, li));
+
+                toggle(li);
+
+                // If it is the root node, expand it again
+                if (node === li.parentNode) {
+                    toggle(li);
+                }
+            }
+        });
+    }
+
+    // Handles a click. The parameter is:
+    //
+    // node - the node for which clicks are being handled
+    function handleClick(node, e){
+        let li = e.target;
+        while (li.nodeName !== 'LI'){
+            li = li.parentNode;
+        }
+
+        if (li === node){
+            toggle(node);
+        }
+    }
+
+    // Opens or closes the unordered list elements directly within the
+    // specified node. The parameter is:
+    //
+    // node - the node containing the unordered list elements
+    function toggle(node){
+        const open = node.classList.contains('collapsibleListClosed');
+        const uls  = node.getElementsByTagName('ul');
+
+        [].forEach.call(uls, ul => {
+
+            let li = ul;
+            while (li.nodeName !== 'LI'){
+                li = li.parentNode;
+            }
+
+            if (li === node){
+                ul.style.display = (open ? 'block' : 'none');
+            }
+
+        });
+
+        node.classList.remove('collapsibleListOpen');
+        node.classList.remove('collapsibleListClosed');
+
+        if (uls.length > 0){
+            node.classList.add('collapsibleList' + (open ? 'Open' : 'Closed'));
+        }
+
+    }
+
+    return {apply, applyTo};
+
+})();
+
+    return {CollapsibleLists};
+})();

--- a/exdir/utils/__init__.py
+++ b/exdir/utils/__init__.py
@@ -1,1 +1,1 @@
-from . import path
+from . import path, display

--- a/exdir/utils/display.py
+++ b/exdir/utils/display.py
@@ -1,0 +1,63 @@
+import pathlib
+import exdir
+
+def _build_tree(o):
+    contents = "<li>"
+    if isinstance(o, exdir.core.File):
+        name = o.root_directory.name
+    else:
+        name = o.object_name
+
+    contents += "{} ({})".format(name, o.__class__.__name__)
+    if isinstance(o, exdir.core.Dataset):
+        contents += "<ul><li>Shape: {}</li><li>Type: {}</li></ul>".format(o.shape, o.dtype)
+    else:
+        try:
+            keys = o.keys()
+            inner_contents = ""
+            for a in keys:
+                inner_contents += _build_tree(o[a])
+            if inner_contents != "":
+                contents += "<ul>{}</ul>".format(inner_contents)
+        except AttributeError:
+            pass
+
+    contents += "</li>"
+
+    return contents
+
+def html_tree(obj):
+    from IPython.core.display import display, HTML
+    import uuid
+
+    ulid=uuid.uuid1()
+
+    style = """
+.collapsibleList li{
+    list-style-type : none;
+    cursor           : auto;
+}
+
+li.collapsibleListOpen{
+    list-style-type : circle;
+    cursor           : pointer;
+}
+
+li.collapsibleListClosed{
+    list-style-type : disc;
+    cursor           : pointer;
+}
+    """
+
+    script = """
+    var node = document.getElementById('{ulid}');
+    exdir.CollapsibleLists.applyTo(node);
+    """.format(ulid=ulid)
+
+    result = ("<style>{style}</style>"
+              "<ul id='{ulid}' class='collapsibleList'>{contents}</ul>"
+              "<script>{script}</script>"
+              "").format(style=style, ulid=ulid, contents=_build_tree(obj), script=script)
+
+    return result
+

--- a/jupyter-config/jupyter_notebook_config.d/exdir.json
+++ b/jupyter-config/jupyter_notebook_config.d/exdir.json
@@ -1,0 +1,7 @@
+{
+  "NotebookApp": {
+    "nbserver_extensions": {
+      "exdir": true
+    }
+  }
+}

--- a/jupyter-config/nbconfig/notebook.d/exdir.json
+++ b/jupyter-config/nbconfig/notebook.d/exdir.json
@@ -1,0 +1,5 @@
+{
+  "load_extensions": {
+    "exdir/index": true
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,22 @@ install_requires = []
 setup(
     name="exdir",
     packages=find_packages(),
-    include_package_data=True, 
+    include_package_data=True,
     version=versioneer.get_version(),
-    cmdclass=versioneer.get_cmdclass()
+    cmdclass=versioneer.get_cmdclass(),
+    data_files=[
+        # like `jupyter nbextension install --sys-prefix`
+        ("share/jupyter/nbextensions/exdir", [
+            "exdir/static/index.js",
+        ]),
+        # like `jupyter nbextension enable --sys-prefix`
+        ("etc/jupyter/nbconfig/notebook.d", [
+            "jupyter-config/nbconfig/notebook.d/exdir.json"
+        ]),
+        # like `jupyter serverextension enable --sys-prefix`
+        ("etc/jupyter/jupyter_notebook_config.d", [
+            "jupyter-config/jupyter_notebook_config.d/exdir.json"
+        ])
+    ],
+    zip_safe=False
 )


### PR DESCRIPTION
A simple implementation for showing Exdir objects as trees in Jupyter notebooks. The tree can be collapsed and expanded by clicking on the different items. Groups expand to their contents while datasets expand to show their shape and type:

![image](https://user-images.githubusercontent.com/220658/48014592-49a00c80-e127-11e8-9eee-c15ab894e228.png)

This makes it much easier to explore Exdir trees without opening a file manager or exdir-browser.

Later, we can use this to add a _repr_html_ function to all Exdir objects. One downside with this implementation is that it will traverse the entire tree, which might not be what we want. We might want to add communication with the kernel so that each node is retrieved only when expanded.