### PR TITLE
Pass the result of one plugin on to the next

### DIFF
--- a/exdir/core/dataset.py
+++ b/exdir/core/dataset.py
@@ -77,13 +77,13 @@ class Dataset(exob.Object):
             meta = self.meta.to_dict()
             atts = self.attrs.to_dict()
 
+            dataset_data = exdir.plugin_interface.DatasetData(data=values,
+                                                              attrs=self.attrs.to_dict(),
+                                                              meta=meta)
             for plugin in plugins:
-                dataset_data = exdir.plugin_interface.DatasetData(data=values,
-                                                                  attrs=self.attrs.to_dict(),
-                                                                  meta=meta)
-
                 dataset_data = plugin.prepare_read(dataset_data)
-                data = dataset_data.data
+
+            data = dataset_data.data
 
         return data
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -211,3 +211,29 @@ def test_attribute_plugin(setup_teardown_folder):
     assert d.attrs["value"] == 84
     f.close()
 
+def test_reading_in_order(setup_teardown_folder):
+    class DatasetPlugin1(exdir.plugin_interface.Dataset):
+        def prepare_read(self, dataset_data):
+            dataset_data.data = dataset_data.data * 2
+            return dataset_data
+
+    class DatasetPlugin2(exdir.plugin_interface.Dataset):
+        def prepare_read(self, dataset_data):
+            dataset_data.data = dataset_data.data * 3
+            return dataset_data
+
+    plugin1 = exdir.plugin_interface.Plugin(
+        "plugin1",
+        dataset_plugins=[DatasetPlugin1()]
+    )
+    plugin2 = exdir.plugin_interface.Plugin(
+        "plugin2",
+        dataset_plugins=[DatasetPlugin2()]
+    )
+
+    f = exdir.File(setup_teardown_folder[1], "w", plugins=[plugin1, plugin2])
+    assert f
+    d = f.create_dataset("foo", data=np.array([1, 2, 3]))
+    assert all(d.data == np.array([6, 12, 18]))
+    f.close()
+


### PR DESCRIPTION
This fixes an issue where only the result of the last plugin would be used when multiple plugins were activated. This also adds a test that catches this issue.