### PR TITLE
Convert path to string in git_lfs_plugin

### DIFF
--- a/exdir/plugins/git_lfs.py
+++ b/exdir/plugins/git_lfs.py
@@ -15,13 +15,13 @@ class DatasetPlugin(exdir.plugin_interface.Dataset):
             contents = f.read(len(test_string))
         if contents == test_string:
             command = ['git', 'rev-parse', '--show-toplevel']
-            git_path = subprocess.check_output(command, cwd=parent_path, stderr=subprocess.STDOUT)
+            git_path = subprocess.check_output(command, cwd=str(parent_path), stderr=subprocess.STDOUT)
             git_path = pathlib.Path(git_path.decode('utf-8').rstrip())
             relative_path = path.relative_to(git_path)
             if self.verbose:
                 print("Fetching Git LFS object for {}".format(relative_path))
             command = ['git', '-c', 'lfs.fetchexclude=""', 'lfs', 'pull', '-I', str(relative_path)]
-            process = subprocess.Popen(command, cwd=git_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            process = subprocess.Popen(command, cwd=str(git_path), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if self.verbose:
                 while not process.poll():
                     # Git LFS has fancy loading output - this doesn't work well in Jupyter,


### PR DESCRIPTION
Seems to be necessary on some Python versions because the subprocess
library does not yet support pathlib.