### PR TITLE
Implement File.close() and more

### DIFF
--- a/exdir/core/attribute.py
+++ b/exdir/core/attribute.py
@@ -144,8 +144,8 @@ class Attribute(object):
             attrs = attrs[i]
         return attrs.values()
 
-    @assert_file_writable
     def _set_data(self, attrs):
+        assert_file_writable(self.file)
         plugins = self.file.plugin_manager.attribute_plugins.write_order
 
         if self.mode == self._Mode.ATTRIBUTES and len(plugins) > 0:
@@ -175,8 +175,8 @@ class Attribute(object):
             )
 
     # TODO only needs filename, make into free function
-    @assert_file_open
     def _open_or_create(self):
+        assert_file_open(self.file)
         attrs = {}
         if self.filename.exists():  # NOTE str for Python 3.5 support
             with self.filename.open("r", encoding="utf-8") as meta_file:
@@ -188,13 +188,13 @@ class Attribute(object):
             yield key
 
     @property
-    @assert_file_open
     def filename(self):
         """
         Returns
         -------
         The filename of the :code:`attributes.yaml` file.
         """
+        assert_file_open(self.file)
         if self.mode == self._Mode.METADATA:
             return self.parent.meta_filename
         else:

--- a/exdir/core/attribute.py
+++ b/exdir/core/attribute.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     import ruamel.yaml as yaml
 
-from .mode import assert_file_open, OpenMode
+from .mode import assert_file_open, OpenMode, assert_file_writable
 
 def _quote_strings(value):
     if isinstance(value, str):
@@ -144,11 +144,8 @@ class Attribute(object):
             attrs = attrs[i]
         return attrs.values()
 
-    @assert_file_open
+    @assert_file_writable
     def _set_data(self, attrs):
-        if self.file.io_mode == OpenMode.READ_ONLY:
-            raise IOError("Cannot write in read only ("r") mode")
-
         plugins = self.file.plugin_manager.attribute_plugins.write_order
 
         if self.mode == self._Mode.ATTRIBUTES and len(plugins) > 0:

--- a/exdir/core/attribute.py
+++ b/exdir/core/attribute.py
@@ -227,3 +227,9 @@ class Attribute(object):
         if self.file.io_mode == OpenMode.FILE_CLOSED:
             return False
         return exdir.utils.display.html_attrs(self)
+
+    def __repr__(self):
+        if self.file.io_mode == OpenMode.FILE_CLOSED:
+            return "<Attributes of closed Exdir object>"
+        return "Attributes of Exdir object '{}' at '{}'".format(
+            self.parent.name, id(self))

--- a/exdir/core/dataset.py
+++ b/exdir/core/dataset.py
@@ -268,6 +268,12 @@ class Dataset(exob.Object):
     def __str__(self):
         return self.data.__str__()
 
+    def __repr__(self):
+        if self.file.io_mode == OpenMode.FILE_CLOSED:
+            return "<Closed Exdir Dataset>"
+        return "<Exdir Dataset {} shape {} dtype {}>".format(
+            self.name, self.shape, self.dtype)
+
     @property
     @assert_file_open
     def _data(self):

--- a/exdir/core/dataset.py
+++ b/exdir/core/dataset.py
@@ -176,6 +176,7 @@ class Dataset(exob.Object):
         return self[:]
 
     @data.setter
+    @assert_file_open
     def data(self, value):
         if self._data.shape != value.shape or self._data.dtype != value.dtype:
             value, attrs, meta = _prepare_write(

--- a/exdir/core/dataset.py
+++ b/exdir/core/dataset.py
@@ -110,6 +110,7 @@ class Dataset(exob.Object):
 
         try:
             self._data_memmap = np.load(self.data_filename, mmap_mode=mmap_mode, allow_pickle=False)
+            self.file._open_datasets[self.name] = self._data_memmap
         except ValueError as e:
             # Could be that it is a Git LFS file. Let's see if that is the case and warn if so.
             with open(self.data_filename, "r") as f:
@@ -130,6 +131,7 @@ class Dataset(exob.Object):
             dtype=value.dtype,
             shape=value.shape
         )
+        self.file._open_datasets[self.name] = self._data_memmap
 
         if len(value.shape) == 0:
             # scalars need to be set with itemset

--- a/exdir/core/dataset.py
+++ b/exdir/core/dataset.py
@@ -3,7 +3,7 @@ import numpy as np
 import exdir
 
 from . import exdir_object as exob
-from .mode import assert_file_open, OpenMode
+from .mode import assert_file_open, OpenMode, assert_file_writable
 
 def _prepare_write(data, plugins, attrs, meta):
     for plugin in plugins:
@@ -85,10 +85,8 @@ class Dataset(exob.Object):
 
         return data
 
-    @assert_file_open
+    @assert_file_writable
     def __setitem__(self, args, value):
-        if self.file.io_mode == OpenMode.READ_ONLY:
-            raise IOError('Cannot write data to file in read only ("r") mode')
 
         value, attrs, meta = _prepare_write(
             data=value,

--- a/exdir/core/exdir_file.py
+++ b/exdir/core/exdir_file.py
@@ -164,7 +164,13 @@ class File(Group):
         Sets the OpenMode to FILE_CLOSED which denies access to any attribute
         """
         # yeah right, as if we would create a real file format
-        self.io_mode = self.OpenMode.FILE_CLOSED
+        self.io_mode = OpenMode.FILE_CLOSED
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
 
     def create_group(self, name):
         """

--- a/exdir/core/exdir_file.py
+++ b/exdir/core/exdir_file.py
@@ -205,3 +205,9 @@ class File(Group):
     def __contains__(self, name):
         path = utils.path.remove_root(name)
         return super(File, self).__contains__(path)
+
+    def __repr__(self):
+        if self.io_mode == OpenMode.FILE_CLOSED:
+            return "<Closed Exdir File>"
+        return "<Exdir File '{}' (mode {})>".format(
+            self.directory, self.user_mode)

--- a/exdir/core/exdir_file.py
+++ b/exdir/core/exdir_file.py
@@ -141,7 +141,7 @@ class File(Group):
         Currently, this has no effect because all data is immediately written to disk.
         """
         # yeah right, as if we would create a real file format
-        pass
+        self.io_mode = self.OpenMode.FILE_CLOSED
 
     def create_group(self, name):
         """

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -189,6 +189,7 @@ class Object(object):
     class OpenMode(Enum):
         READ_WRITE = 1
         READ_ONLY = 2
+        FILE_CLOSED = 3
 
     def __init__(self, root_directory, parent_path, object_name, io_mode=None,
                  name_validation=None, plugin_manager=None):

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -20,11 +20,10 @@ except ImportError:
 
 import exdir
 
-from . import validation
-# from . import exdir_object
 from .. import utils
 from .attribute import Attribute
 from .constants import *
+from .mode import assert_file_open, OpenMode
 
 def _resolve_path(path):
     return pathlib.Path(path).resolve()
@@ -32,7 +31,7 @@ def _resolve_path(path):
 
 def _assert_valid_name(name, container):
     """Check if name (dataset or group) is valid."""
-    container.name_validation(container.directory, name)
+    container.file.name_validation(container.directory, name)
 
 
 def _create_object_directory(directory, metadata):
@@ -179,6 +178,7 @@ def open_object(path):
         return exdir_file
     return exdir_file[object_name]
 
+
 # NOTE This is in a separate file only because of circular imports between Object and Raw otherwise
 # TODO move this back to Object once circular imports are figured out
 
@@ -186,14 +186,7 @@ class Object(object):
     """
     Parent class for exdir Group and exdir dataset objects
     """
-    class OpenMode(Enum):
-        READ_WRITE = 1
-        READ_ONLY = 2
-        FILE_CLOSED = 3
-
-    def __init__(self, root_directory, parent_path, object_name, io_mode=None,
-                 name_validation=None, plugin_manager=None):
-        # TODO put io_mode, name_validation, plugin_types into a configuration object
+    def __init__(self, root_directory, parent_path, object_name, file):
         self.root_directory = root_directory
         self.object_name = str(object_name)  # NOTE could be path, so convert to str
         self.parent_path = parent_path
@@ -202,69 +195,44 @@ class Object(object):
         if relative_name == ".":
             relative_name = ""
         self.name = "/" + relative_name
-        self.io_mode = io_mode
-        self.plugin_manager = plugin_manager
+        self.file = file
 
-        name_validation = name_validation or validation.thorough
-
-        if isinstance(name_validation, str):
-            if name_validation == 'simple':
-                name_validation = validation.thorough
-            elif name_validation == 'thorough':
-                name_validation = validation.thorough
-            elif name_validation == 'strict':
-                name_validation = validation.strict
-            elif name_validation == 'none':
-                name_validation = validation.none
-            else:
-                raise ValueError(
-                    'IO name rule "{}" not recognized, '
-                    'name rule must be one of "strict", "simple", '
-                    '"thorough", "none"'.format(name_validation)
-                )
-
-            warnings.warn(
-                "WARNING: name_validation should be set to one of the functions in "
-                "the exdir.validation module. "
-                "Defining naming rule by string is no longer supported."
-            )
-
-        self.name_validation = name_validation
-
-    @property
+    @property # TODO consider warning if file is closed
     def directory(self):
         return self.root_directory / self.relative_path
 
     @property
+    @assert_file_open
     def attrs(self):
         return Attribute(
             self,
             mode=Attribute._Mode.ATTRIBUTES,
-            io_mode=self.io_mode,
-            plugin_manager=self.plugin_manager
+            file=self.file,
         )
 
     @attrs.setter
+    @assert_file_open
     def attrs(self, value):
         self.attrs._set_data(value)
 
     @property
+    @assert_file_open
     def meta(self):
         return Attribute(
             self,
             mode=Attribute._Mode.METADATA,
-            io_mode=self.io_mode,
-            plugin_manager=self.plugin_manager
+            file=self.file,
         )
 
-    @property
+    @property # TODO consider warning if file is closed,
     def attributes_filename(self):
         return self.directory / ATTRIBUTES_FILENAME
 
-    @property
+    @property # TODO consider warning if file is closed
     def meta_filename(self):
         return self.directory / META_FILENAME
 
+    @assert_file_open
     def create_raw(self, name):
         from .raw import Raw
         _assert_valid_name(name, self)
@@ -276,9 +244,10 @@ class Object(object):
             root_directory=self.root_directory,
             parent_path=self.relative_path,
             object_name=name,
-            io_mode=self.io_mode
+            file=self.file
         )
 
+    @assert_file_open
     def require_raw(self, name):
         from .raw import Raw
         directory_name = self.directory / name
@@ -291,12 +260,13 @@ class Object(object):
                 root_directory=self.root_directory,
                 parent_path=self.relative_path,
                 object_name=name,
-                io_mode=self.io_mode
+                file=self.file
             )
 
         return self.create_raw(name)
 
     @property
+    @assert_file_open
     def parent(self):
         from .group import Group
         if len(self.parent_path.parts) < 1:
@@ -307,12 +277,12 @@ class Object(object):
             root_directory=self.root_directory,
             parent_path=parent_parent_path,
             object_name=parent_name,
-            io_mode=self.io_mode,
-            name_validation=self.name_validation,
-            plugin_manager=self.plugin_manager
+            file=self.file
         )
 
     def __eq__(self, other):
+        if self.file.io_mode == OpenMode.FILE_CLOSED:
+            return False
         if not isinstance(other, Object):
             return False
         return (

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -299,4 +299,4 @@ class Object(object):
         if self.file.io_mode == OpenMode.FILE_CLOSED:
             return "<Closed Exdir Group>"
         return "<Exdir Group '{}' (mode {})>".format(
-            self.directory, self.user_mode)
+            self.directory, self.file.user_mode)

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -202,8 +202,8 @@ class Object(object):
         return self.root_directory / self.relative_path
 
     @property
-    @assert_file_open
     def attrs(self):
+        assert_file_open(self.file)
         return Attribute(
             self,
             mode=Attribute._Mode.ATTRIBUTES,
@@ -211,13 +211,13 @@ class Object(object):
         )
 
     @attrs.setter
-    @assert_file_open
     def attrs(self, value):
+        assert_file_open(self.file)
         self.attrs._set_data(value)
 
     @property
-    @assert_file_open
     def meta(self):
+        assert_file_open(self.file)
         return Attribute(
             self,
             mode=Attribute._Mode.METADATA,
@@ -232,9 +232,9 @@ class Object(object):
     def meta_filename(self):
         return self.directory / META_FILENAME
 
-    @assert_file_open
     def create_raw(self, name):
         from .raw import Raw
+        assert_file_open(self.file)
         _assert_valid_name(name, self)
         directory_name = self.directory / name
         if directory_name.exists():
@@ -247,9 +247,9 @@ class Object(object):
             file=self.file
         )
 
-    @assert_file_open
     def require_raw(self, name):
         from .raw import Raw
+        assert_file_open(self.file)
         directory_name = self.directory / name
         if directory_name.exists():
             if is_nonraw_object_directory(directory_name):
@@ -266,9 +266,9 @@ class Object(object):
         return self.create_raw(name)
 
     @property
-    @assert_file_open
     def parent(self):
         from .group import Group
+        assert_file_open(self.file)
         if len(self.parent_path.parts) < 1:
             return None
         parent_name = self.parent_path.name

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -291,4 +291,12 @@ class Object(object):
         )
 
     def _repr_html_(self):
+        if self.file.io_mode == OpenMode.FILE_CLOSED:
+            return None
         return exdir.utils.display.html_tree(self)
+
+    def __repr__(self):
+        if self.file.io_mode == OpenMode.FILE_CLOSED:
+            return "<Closed Exdir Group>"
+        return "<Exdir Group '{}' (mode {})>".format(
+            self.directory, self.user_mode)

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -290,6 +290,11 @@ class Object(object):
             self.root_directory == other.root_directory
         )
 
+    def __bool__(self):
+        if self.file.io_mode == OpenMode.FILE_CLOSED:
+            return False
+        return True
+
     def _repr_html_(self):
         if self.file.io_mode == OpenMode.FILE_CLOSED:
             return None

--- a/exdir/core/group.py
+++ b/exdir/core/group.py
@@ -19,7 +19,7 @@ except ImportError:
     import collections as abc
 
 from .exdir_object import Object
-from .mode import assert_file_open, OpenMode
+from .mode import assert_file_open, OpenMode, assert_file_writable
 from . import exdir_object as exob
 from . import dataset as ds
 from . import raw
@@ -69,7 +69,7 @@ class Group(Object):
             file=file
         )
 
-    @assert_file_open
+    @assert_file_writable
     def create_dataset(self, name, shape=None, dtype=None,
                        data=None, fillvalue=None):
         """
@@ -112,11 +112,6 @@ class Group(Object):
         """
         exob._assert_valid_name(name, self)
 
-        if self.file.io_mode == OpenMode.READ_ONLY:
-            raise IOError("Cannot write data to file in read only ('r') mode")
-
-        exob._assert_valid_name(name, self)
-
         if data is None and shape is None:
             raise TypeError(
                 "Cannot create dataset. Missing shape or data keyword."
@@ -153,7 +148,7 @@ class Group(Object):
         dataset._reset_data(prepared_data, attrs, None)  # meta already set above
         return dataset
 
-    @assert_file_open
+    @assert_file_writable
     def create_group(self, name):
         """
         Create a group. This will create a folder on the filesystem with the
@@ -178,9 +173,6 @@ class Group(Object):
         --------
         require_group
         """
-        if self.file.io_mode == OpenMode.READ_ONLY:
-            raise IOError("Cannot write data to file in read only ("r") mode")
-
         path = utils.path.name_to_asserted_group_path(name)
         if len(path.parts) > 1:
             subgroup = self.require_group(path.parent)
@@ -458,7 +450,7 @@ class Group(Object):
 
         self[name].value = value
 
-    @assert_file_open
+    @assert_file_writable
     def __delitem__(self, name):
         """
         Delete a child (an object contained in group).
@@ -468,8 +460,6 @@ class Group(Object):
         name: str
             name of the existing child
         """
-        if self.file.io_mode == OpenMode.READ_ONLY:
-            raise IOError("Cannot change data on file in read only 'r' mode")
         exob._remove_object_directory(self[name].directory)
 
     @assert_file_open

--- a/exdir/core/group.py
+++ b/exdir/core/group.py
@@ -69,7 +69,6 @@ class Group(Object):
             file=file
         )
 
-    @assert_file_writable
     def create_dataset(self, name, shape=None, dtype=None,
                        data=None, fillvalue=None):
         """
@@ -110,6 +109,7 @@ class Group(Object):
         --------
         require_dataset
         """
+        assert_file_writable(self.file)
         exob._assert_valid_name(name, self)
 
         if data is None and shape is None:
@@ -148,7 +148,6 @@ class Group(Object):
         dataset._reset_data(prepared_data, attrs, None)  # meta already set above
         return dataset
 
-    @assert_file_writable
     def create_group(self, name):
         """
         Create a group. This will create a folder on the filesystem with the
@@ -173,6 +172,7 @@ class Group(Object):
         --------
         require_group
         """
+        assert_file_writable(self.file)
         path = utils.path.name_to_asserted_group_path(name)
         if len(path.parts) > 1:
             subgroup = self.require_group(path.parent)
@@ -198,7 +198,6 @@ class Group(Object):
             file=self.file
         )
 
-    @assert_file_open
     def require_group(self, name):
         """
         Open an existing subgroup or create one if it does not exist.
@@ -217,6 +216,7 @@ class Group(Object):
         --------
         create_group
         """
+        assert_file_open(self.file)
         path = utils.path.name_to_asserted_group_path(name)
         if len(path.parts) > 1:
             subgroup = self.require_group(path.parent)
@@ -241,7 +241,6 @@ class Group(Object):
 
         return self.create_group(name)
 
-    @assert_file_open
     def require_dataset(self, name, shape=None, dtype=None, exact=False,
                         data=None, fillvalue=None):
         """
@@ -279,6 +278,7 @@ class Group(Object):
             Used to create a dataset with the given `shape` and `type` with the
             initial value of `fillvalue`.
         """
+        assert_file_open(self.file)
         if name not in self:
             return self.create_dataset(
                 name,
@@ -352,7 +352,6 @@ class Group(Object):
         directory = self.directory / path
         return exob.is_exdir_object(directory)
 
-    @assert_file_open
     def __getitem__(self, name):
         """
         Retrieves the object with the given name if it exists in the group.
@@ -367,6 +366,7 @@ class Group(Object):
         KeyError:
             if the name does not correspond to an exdir object in the group
         """
+        assert_file_open(self.file)
         path = utils.path.name_to_asserted_group_path(name)
         if len(path.parts) > 1:
             top_directory = path.parts[0]
@@ -421,7 +421,6 @@ class Group(Object):
             file=self.file
         )
 
-    @assert_file_open
     def __setitem__(self, name, value):
         """
         Set or create a dataset with the given name from the given value.
@@ -434,6 +433,7 @@ class Group(Object):
             value that will be used to create a new or set
             the contents of an existing dataset
         """
+        assert_file_open(self.file)
         path = utils.path.name_to_asserted_group_path(name)
         if len(path.parts) > 1:
             self[path.parent][path.name] = value
@@ -450,7 +450,6 @@ class Group(Object):
 
         self[name].value = value
 
-    @assert_file_writable
     def __delitem__(self, name):
         """
         Delete a child (an object contained in group).
@@ -460,9 +459,9 @@ class Group(Object):
         name: str
             name of the existing child
         """
+        assert_file_writable(self.file)
         exob._remove_object_directory(self[name].directory)
 
-    @assert_file_open
     def keys(self):
         """
         Returns
@@ -470,9 +469,9 @@ class Group(Object):
         KeysView
             A view of the names of the objects in the group.
         """
+        assert_file_open(self.file)
         return abc.KeysView(self)
 
-    @assert_file_open
     def items(self):
         """
         Returns
@@ -480,9 +479,9 @@ class Group(Object):
         ItemsView
             A view of the keys and objects in the group.
         """
+        assert_file_open(self.file)
         return abc.ItemsView(self)
 
-    @assert_file_open
     def values(self):
         """
         Returns
@@ -490,26 +489,26 @@ class Group(Object):
         ValuesView
             A view of the objects in the group.
         """
+        assert_file_open(self.file)
         return abc.ValuesView(self)
 
-    @assert_file_open
     def __iter__(self):
         """
         Iterate over all the objects in the group.
         """
+        assert_file_open(self.file)
         # NOTE os.walk is way faster than os.listdir + os.path.isdir
         directories = next(os.walk(str(self.directory)))[1]
         for name in sorted(directories):
             yield name
 
-    @assert_file_open
     def __len__(self):
         """
         Number of objects in the group.
         """
+        assert_file_open(self.file)
         return len([a for a in self])
 
-    @assert_file_open
     def get(self, key):
         """
         Get an object in the group.
@@ -521,6 +520,7 @@ class Group(Object):
         -------
         Value or None if object does not exist.
         """
+        assert_file_open(self.file)
         if key in self:
             return self[key]
         else:

--- a/exdir/core/mode.py
+++ b/exdir/core/mode.py
@@ -7,26 +7,20 @@ class OpenMode(Enum):
     FILE_CLOSED = 3
 
 
-def assert_file_open(func):
+def assert_file_open(file_object):
     """
     Decorator to check if the file is not closed.
     """
-    def wrapper(self, *args, **kwargs):
-        if self.file.io_mode == OpenMode.FILE_CLOSED:
-            raise IOError("Unable to operate on closed File instance.")
-        return func(self, *args, **kwargs)
-    return wrapper
+    if file_object.io_mode == OpenMode.FILE_CLOSED:
+        raise IOError("Unable to operate on closed File instance.")
 
 
-def assert_file_writable(func):
+def assert_file_writable(file_object):
     """
     Decorator to check if the file is not closed,
     and that it is not in read only mode.
     """
-    def wrapper(self, *args, **kwargs):
-        if self.file.io_mode == OpenMode.FILE_CLOSED:
-            raise IOError("Unable to operate on closed File instance.")
-        if self.file.io_mode == OpenMode.READ_ONLY:
-            raise IOError("Cannot change data on file in read only 'r' mode")
-        return func(self, *args, **kwargs)
-    return wrapper
+    if file_object.io_mode == OpenMode.FILE_CLOSED:
+        raise IOError("Unable to operate on closed File instance.")
+    if file_object.io_mode == OpenMode.READ_ONLY:
+        raise IOError("Cannot change data on file in read only 'r' mode")

--- a/exdir/core/mode.py
+++ b/exdir/core/mode.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class OpenMode(Enum):
+    READ_WRITE = 1
+    READ_ONLY = 2
+    FILE_CLOSED = 3
+
+
+def assert_file_open(func):
+    def wrapper(self, *args, **kwargs):
+        if self.file.io_mode == OpenMode.FILE_CLOSED:
+            raise IOError("Unable to operate on closed File instance.")
+        return func(self, *args, **kwargs)
+    return wrapper

--- a/exdir/core/mode.py
+++ b/exdir/core/mode.py
@@ -8,8 +8,25 @@ class OpenMode(Enum):
 
 
 def assert_file_open(func):
+    """
+    Decorator to check if the file is not closed.
+    """
     def wrapper(self, *args, **kwargs):
         if self.file.io_mode == OpenMode.FILE_CLOSED:
             raise IOError("Unable to operate on closed File instance.")
+        return func(self, *args, **kwargs)
+    return wrapper
+
+
+def assert_file_writable(func):
+    """
+    Decorator to check if the file is not closed,
+    and that it is not in read only mode.
+    """
+    def wrapper(self, *args, **kwargs):
+        if self.file.io_mode == OpenMode.FILE_CLOSED:
+            raise IOError("Unable to operate on closed File instance.")
+        if self.file.io_mode == OpenMode.READ_ONLY:
+            raise IOError("Cannot change data on file in read only 'r' mode")
         return func(self, *args, **kwargs)
     return wrapper

--- a/exdir/core/raw.py
+++ b/exdir/core/raw.py
@@ -7,11 +7,10 @@ class Raw(exob.Object):
 
     Raw objects currently have no features apart from showing their path.
     """
-    def __init__(self, root_directory, parent_path, object_name, io_mode=None, plugin_manager=None):
+    def __init__(self, root_directory, parent_path, object_name, file):
         super(Raw, self).__init__(
             root_directory=root_directory,
             parent_path=parent_path,
             object_name=object_name,
-            io_mode=io_mode,
-            plugin_manager=plugin_manager
+            file=file
         )

--- a/tests/test_attr.py
+++ b/tests/test_attr.py
@@ -23,11 +23,11 @@ from exdir.core import Attribute, File
 import six
 
 def test_attr_init():
-    attribute = Attribute("parent", "mode", "io_mode")
+    attribute = Attribute("parent", "mode", "file")
 
     assert attribute.parent == "parent"
     assert attribute.mode == "mode"
-    assert attribute.io_mode == "io_mode"
+    assert attribute.file == "file"
     assert attribute.path == []
 
 # Attribute creation/retrieval via special methods

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -138,8 +138,7 @@ def test_readonly(setup_teardown_folder):
 
     f = File(setup_teardown_folder[1], 'w')
     f.close()
-    # TODO comment in when close is implemented
-    # assert not f
+    assert not f
     f = File(setup_teardown_folder[1], 'r')
     assert isinstance(f, File)
     with pytest.raises(IOError):
@@ -307,7 +306,6 @@ def test_open_two_attrs(setup_teardown_file):
     f.attrs['another_atribute'] = 14
 
 
-# TODO uncomment this when close is implemented
 def test_exc(setup_teardown_file):
     """'in' on closed group returns False."""
     f = setup_teardown_file[3]

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -324,14 +324,14 @@ def test_contains_deep(setup_teardown_file):
 
 
 # TODO uncomment this when close is implemented
-# def test_exc(setup_teardown_file):
-#     """'in' on closed group returns False."""
-#     f = setup_teardown_file[3]
-#
-#     f.create_group("a")
-#     f.close()
-#
-#     assert not "a" in f
+def test_exc(setup_teardown_file):
+    """'in' on closed group returns False."""
+    f = setup_teardown_file[3]
+
+    f.create_group("a")
+    f.close()
+
+    assert not "a" in f
 
 
 def test_empty(setup_teardown_file):

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -33,12 +33,12 @@ from conftest import remove
 
 # tests for Group class
 def test_group_init(setup_teardown_folder):
-    group = Group(setup_teardown_folder[2], pathlib.PurePosixPath(""), "test_object", io_mode=None)
+    group = Group(setup_teardown_folder[2], pathlib.PurePosixPath(""), "test_object", file=None)
 
     assert group.root_directory == setup_teardown_folder[2]
     assert group.object_name == "test_object"
     assert group.parent_path == pathlib.PurePosixPath("")
-    assert group.io_mode is None
+    assert group.file is None
     assert group.relative_path == pathlib.PurePosixPath("test_object")
     assert group.name == "/test_object"
 
@@ -321,17 +321,6 @@ def test_contains_deep(setup_teardown_file):
     grp3 = grp2.create_group("b")
 
     assert "a/b" in grp
-
-
-# TODO uncomment this when close is implemented
-def test_exc(setup_teardown_file):
-    """'in' on closed group returns False."""
-    f = setup_teardown_file[3]
-
-    f.create_group("a")
-    f.close()
-
-    assert not "a" in f
 
 
 def test_empty(setup_teardown_file):

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -36,12 +36,12 @@ import exdir.core.exdir_object as exob
 # tests for Object class
 
 def test_object_init(setup_teardown_folder):
-    obj = Object(setup_teardown_folder[2], pathlib.PurePosixPath(""), "test_object", io_mode=None)
+    obj = Object(setup_teardown_folder[2], pathlib.PurePosixPath(""), "test_object", file=None)
 
     assert obj.root_directory == setup_teardown_folder[2]
     assert obj.object_name == "test_object"
     assert obj.parent_path == pathlib.PurePosixPath("")
-    assert obj.io_mode is None
+    assert obj.file is None
     assert obj.relative_path == pathlib.PurePosixPath("test_object")
     assert obj.name == "/test_object"
 

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -10,12 +10,12 @@ except ImportError as e:
 from exdir.core import Raw
 
 def test_raw_init(setup_teardown_folder):
-    raw = Raw(setup_teardown_folder[2], pathlib.PurePosixPath(""), "test_object", io_mode=None)
+    raw = Raw(setup_teardown_folder[2], pathlib.PurePosixPath(""), "test_object", file=None)
 
     assert raw.root_directory == setup_teardown_folder[2]
     assert raw.object_name == "test_object"
     assert raw.parent_path == pathlib.PurePosixPath("")
-    assert raw.io_mode is None
+    assert raw.file is None
     assert raw.relative_path == pathlib.PurePosixPath("test_object")
     assert raw.name == "/test_object"
 


### PR DESCRIPTION
* FILE_CLOSED is a new io_mode
* close and context managing implemented
* Mode checking is done through specific decorators kept in a new module `mode.py`
* The file object is passed throughout the objects and contains `io_mode`, `name_validation` and `plugin_manager`.
* Various fixes on `__repr__` and added some new methods.

All in all I think this is a good start on a proper implementation of close, issues and things to consider are
* Unable to close memmaped files - numpy has no explicit close method; see https://github.com/numpy/numpy/issues/13510
* I started to reference opened datasets, we could consider referencing all opened YAML files as well and keep them open until `File.close()` is called. This might enable a speedup.