### PR TITLE
Support for pandas DataFrame

### DIFF
--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - numpy
     - scipy
     - ruamel_yaml
+    - pandas
     - pyyaml
     - pathlib # [py2k]
     - enum34  # [py2k]
@@ -34,6 +35,7 @@ test:
     - pytest
     - pytest-benchmark
     - h5py
+    - pandas
     - six
     - coverage
     - codecov

--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - scipy
     - ruamel_yaml
     - pandas
+    - pyarrow
     - pyyaml
     - pathlib # [py2k]
     - enum34  # [py2k]
@@ -35,6 +36,7 @@ test:
     - pytest
     - pytest-benchmark
     - h5py
+    - pyarrow
     - pandas
     - six
     - coverage

--- a/exdir/__init__.py
+++ b/exdir/__init__.py
@@ -1,7 +1,10 @@
 from . import core
 from . import plugin_interface
 from . import plugins
-from .core import File, validation, Attribute, Dataset, Group, Raw, Object
+from .core import (
+    File, validation, Attribute, Dataset, Group, Raw, Object, SoftLink,
+    ExternalLink
+)
 
 # TODO remove versioneer
 from ._version import get_versions

--- a/exdir/core/__init__.py
+++ b/exdir/core/__init__.py
@@ -11,3 +11,4 @@ from .attribute import Attribute
 from .dataset import Dataset
 from .group import Group
 from .raw import Raw
+from .links import SoftLink, ExternalLink

--- a/exdir/core/constants.py
+++ b/exdir/core/constants.py
@@ -2,6 +2,15 @@
 EXDIR_METANAME = "exdir"
 TYPE_METANAME = "type"
 VERSION_METANAME = "version"
+LINK_METANAME = "link"
+TARGET_METANAME = "target"
+
+#links
+LINK_TYPENAME = "link"
+LINK_TARGETNAME = "target"
+LINK_EXTERNALNAME = "external"
+LINK_SOFTNAME = "soft"
+LINK_FILENAME = "file"
 
 # filenames
 META_FILENAME = "exdir.yaml"

--- a/exdir/core/dataset.py
+++ b/exdir/core/dataset.py
@@ -128,6 +128,9 @@ class Dataset(exob.Object):
                 self._data_loaded = feather.read_feather(str(data_filename))
             self.file._open_datasets[self.name] = self
         except ValueError as e:
+            # Could be that numpy needs to pickle, suggest the user to use
+            # dataframe
+            
             # Could be that it is a Git LFS file.
             # Let's see if that is the case and warn if so.
             with open(str(data_filename), "r") as f:
@@ -216,7 +219,7 @@ class Dataset(exob.Object):
             if hasattr(self._data, 'dtype'):
                 new_dtype = self._data.dtype != value.dtype
             else:
-                new_dtype = True # changing from feather to numpy 
+                new_dtype = True # changing from feather to numpy
             if self._data.shape != value.shape or new_dtype:
                 value, attrs, meta = _prepare_write(
                     data=value,

--- a/exdir/core/dataset.py
+++ b/exdir/core/dataset.py
@@ -1,9 +1,15 @@
 import numbers
 import numpy as np
+import pyarrow.feather as feather
+import pandas as pd
 import exdir
 
 from . import exdir_object as exob
 from .mode import assert_file_open, OpenMode, assert_file_writable
+
+NUMPY_SUFFIX = '.npy'
+FEATHER_SUFFIX = '.feather'
+
 
 def _prepare_write(data, plugins, attrs, meta):
     for plugin in plugins:
@@ -25,7 +31,12 @@ def _prepare_write(data, plugins, attrs, meta):
 
 
 def _dataset_filename(dataset_directory):
-    return dataset_directory / "data.npy"
+    base = dataset_directory / "data"
+    if base.with_suffix(FEATHER_SUFFIX).exists():
+        filename = base.with_suffix(FEATHER_SUFFIX)
+    else:
+        filename = base.with_suffix(NUMPY_SUFFIX)
+    return filename
 
 
 class Dataset(exob.Object):
@@ -44,9 +55,8 @@ class Dataset(exob.Object):
             object_name=object_name,
             file=file
         )
-        self._data_memmap = None
+        self._data_loaded = None
         self.plugin_manager = file.plugin_manager
-        self.data_filename = str(_dataset_filename(self.directory))
 
     def __getitem__(self, args):
         assert_file_open(self.file)
@@ -75,9 +85,8 @@ class Dataset(exob.Object):
             meta = self.meta.to_dict()
             atts = self.attrs.to_dict()
 
-            dataset_data = exdir.plugin_interface.DatasetData(data=values,
-                                                              attrs=self.attrs.to_dict(),
-                                                              meta=meta)
+            dataset_data = exdir.plugin_interface.DatasetData(
+                data=values, attrs=self.attrs.to_dict(), meta=meta)
             for plugin in plugins:
                 dataset_data = plugin.prepare_read(dataset_data)
 
@@ -100,8 +109,10 @@ class Dataset(exob.Object):
 
     def _reload_data(self):
         assert_file_open(self.file)
+        data_filename = _dataset_filename(self.directory)
         for plugin in self.plugin_manager.dataset_plugins.write_order:
-            plugin.before_load(self.data_filename)
+            plugin.before_load(str(data_filename))
+
 
         if self.file.io_mode == OpenMode.READ_ONLY:
             mmap_mode = "r"
@@ -109,35 +120,51 @@ class Dataset(exob.Object):
             mmap_mode = "r+"
 
         try:
-            self._data_memmap = np.load(self.data_filename, mmap_mode=mmap_mode, allow_pickle=False)
+            if data_filename.suffix == NUMPY_SUFFIX:
+                self._data_loaded = np.load(
+                    str(data_filename),
+                    mmap_mode=mmap_mode, allow_pickle=False)
+            else:
+                self._data_loaded = feather.read_feather(str(data_filename))
             self.file._open_datasets[self.name] = self
         except ValueError as e:
-            # Could be that it is a Git LFS file. Let's see if that is the case and warn if so.
-            with open(self.data_filename, "r") as f:
+            # Could be that it is a Git LFS file.
+            # Let's see if that is the case and warn if so.
+            with open(str(data_filename), "r") as f:
                 test_string = "version https://git-lfs.github.com/spec/v1"
                 contents = f.read(len(test_string))
                 if contents == test_string:
                     raise IOError("The file '{}' is a Git LFS placeholder. "
-                        "Open the the Exdir File with the Git LFS plugin or run "
-                        "`git lfs fetch` first. ".format(self.data_filename))
+                        "Open the the Exdir File with the Git LFS plugin or run"
+                        " `git lfs fetch` first. ".format(str(data_filename)))
                 else:
                     raise e
 
     def _reset_data(self, value, attrs, meta):
         assert_file_open(self.file)
-        self._data_memmap = np.lib.format.open_memmap(
-            self.data_filename,
-            mode="w+",
-            dtype=value.dtype,
-            shape=value.shape
-        )
-
-        if len(value.shape) == 0:
-            # scalars need to be set with itemset
-            self._data_memmap.itemset(value)
+        data_filename = _dataset_filename(self.directory)
+        if isinstance(value, pd.DataFrame):
+            feather.write_feather(
+                value, str(data_filename.with_suffix(FEATHER_SUFFIX)))
+            if data_filename.with_suffix(NUMPY_SUFFIX).exists():
+                data_filename.with_suffix(NUMPY_SUFFIX).unlink()
         else:
-            # replace the contents with the value
-            self._data_memmap[:] = value
+            self._data_loaded = np.lib.format.open_memmap(
+                str(data_filename.with_suffix(NUMPY_SUFFIX)),
+                mode="w+",
+                dtype=value.dtype,
+                shape=value.shape
+            )
+
+            if len(value.shape) == 0:
+                # scalars need to be set with itemset
+                self._data_loaded.itemset(value)
+            else:
+                # replace the contents with the value
+                self._data_loaded[:] = value
+
+            if data_filename.with_suffix(FEATHER_SUFFIX).exists():
+                data_filename.with_suffix(FEATHER_SUFFIX).unlink()
 
         # update attributes and plugin metadata
         if attrs:
@@ -177,7 +204,7 @@ class Dataset(exob.Object):
     @data.setter
     def data(self, value):
         assert_file_open(self.file)
-        if self._data.shape != value.shape or self._data.dtype != value.dtype:
+        if isinstance(value, pd.DataFrame):
             value, attrs, meta = _prepare_write(
                 data=value,
                 plugins=self.plugin_manager.dataset_plugins.write_order,
@@ -185,9 +212,22 @@ class Dataset(exob.Object):
                 meta=self.meta.to_dict()
             )
             self._reset_data(value, attrs, meta)
-            return
+        else:
+            if hasattr(self._data, 'dtype'):
+                new_dtype = self._data.dtype != value.dtype
+            else:
+                new_dtype = True # changing from feather to numpy 
+            if self._data.shape != value.shape or new_dtype:
+                value, attrs, meta = _prepare_write(
+                    data=value,
+                    plugins=self.plugin_manager.dataset_plugins.write_order,
+                    attrs=self.attrs.to_dict(),
+                    meta=self.meta.to_dict()
+                )
+                self._reset_data(value, attrs, meta)
+                return
 
-        self[:] = value
+            self[:] = value
 
     @property
     def shape(self):
@@ -270,12 +310,12 @@ class Dataset(exob.Object):
     def __repr__(self):
         if self.file.io_mode == OpenMode.FILE_CLOSED:
             return "<Closed Exdir Dataset>"
-        return "<Exdir Dataset {} shape {} dtype {}>".format(
-            self.name, self.shape, self.dtype)
+        return "<Exdir Dataset {} shape {}>".format(
+            self.name, self.shape)
 
     @property
     def _data(self):
         assert_file_open(self.file)
-        if self._data_memmap is None:
+        if self._data_loaded is None:
             self._reload_data()
-        return self._data_memmap
+        return self._data_loaded

--- a/exdir/core/exdir_file.py
+++ b/exdir/core/exdir_file.py
@@ -179,6 +179,12 @@ class File(Group):
             return self
         return super(File, self).__getitem__(path)
 
+    def __setitem__(self, name, value):
+        path = utils.path.remove_root(name)
+        if len(path.parts) < 1:
+            return self
+        return super(File, self).__setitem__(path, value)
+
     def __contains__(self, name):
         path = utils.path.remove_root(name)
         return super(File, self).__contains__(path)

--- a/exdir/core/exdir_file.py
+++ b/exdir/core/exdir_file.py
@@ -170,8 +170,8 @@ class File(Group):
             # there are no way to close the memmap other than deleting all
             # references to it, thus
             try:
-                data_set._data_memmap.flush()
-                data_set._data_memmap.setflags(write=False) # TODO does not work
+                data_set._data_loaded.flush()
+                data_set._data_loaded.setflags(write=False) # TODO does not work
             except AttributeError:
                 pass
         # force garbage collection to clean weakrefs

--- a/exdir/core/exdir_file.py
+++ b/exdir/core/exdir_file.py
@@ -71,7 +71,7 @@ class File(Group):
     def __init__(self, directory, mode=None, allow_remove=False,
                  name_validation=None, plugins=None):
         self._open_datasets = weakref.WeakValueDictionary({})
-        directory = pathlib.Path(directory) #.resolve()
+        directory = pathlib.Path(directory).absolute() #.resolve()
         if directory.suffix != ".exdir":
             directory = directory.with_suffix(directory.suffix + ".exdir")
         self.user_mode = mode = mode or 'a'

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -113,7 +113,8 @@ def is_nonraw_object_directory(directory):
             return False
         if TYPE_METANAME not in meta_data[EXDIR_METANAME]:
             return False
-        valid_types = [DATASET_TYPENAME, FILE_TYPENAME, GROUP_TYPENAME]
+        valid_types = [
+            DATASET_TYPENAME, FILE_TYPENAME, GROUP_TYPENAME, LINK_METANAME]
         if meta_data[EXDIR_METANAME][TYPE_METANAME] not in valid_types:
             return False
     return True
@@ -121,6 +122,29 @@ def is_nonraw_object_directory(directory):
 
 def is_raw_object_directory(directory):
     return is_exdir_object(directory) and not is_nonraw_object_directory(directory)
+
+
+def is_link_object_directory(directory):
+    if not is_exdir_object(directory):
+        return False
+    meta_filename = directory / META_FILENAME
+    if not meta_filename.exists():
+        return False
+    with meta_filename.open("r", encoding="utf-8") as meta_file:
+        meta_data = yaml.safe_load(meta_file)
+
+        if not isinstance(meta_data, dict):
+            return False
+
+        if EXDIR_METANAME not in meta_data:
+            return False
+
+        if TYPE_METANAME not in meta_data[EXDIR_METANAME]:
+            return False
+
+        if meta_data[EXDIR_METANAME][TYPE_METANAME] == LINK_METANAME:
+            return True
+    return False
 
 
 def root_directory(path):

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -124,29 +124,6 @@ def is_raw_object_directory(directory):
     return is_exdir_object(directory) and not is_nonraw_object_directory(directory)
 
 
-def is_link_object_directory(directory):
-    if not is_exdir_object(directory):
-        return False
-    meta_filename = directory / META_FILENAME
-    if not meta_filename.exists():
-        return False
-    with meta_filename.open("r", encoding="utf-8") as meta_file:
-        meta_data = yaml.safe_load(meta_file)
-
-        if not isinstance(meta_data, dict):
-            return False
-
-        if EXDIR_METANAME not in meta_data:
-            return False
-
-        if TYPE_METANAME not in meta_data[EXDIR_METANAME]:
-            return False
-
-        if meta_data[EXDIR_METANAME][TYPE_METANAME] == LINK_METANAME:
-            return True
-    return False
-
-
 def root_directory(path):
     """
     Iterates upwards until a exdir.File object is found.

--- a/exdir/core/group.py
+++ b/exdir/core/group.py
@@ -323,6 +323,11 @@ class Group(Object):
 
 
         # TODO verify proper attributes
+        if not isinstance(data, type(current_object.data)):
+            raise IOError(
+                'Not allowed to change data instance with "require_dataset"'
+                '(existing {} vs new {}), set data if a change is desired.'
+                ''.format(type(current_object.data), type(data)))
         if not isinstance(data, pd.DataFrame):
             _assert_data_shape_dtype_match(data, shape, dtype)
             shape, dtype = _data_to_shape_and_dtype(data, shape, dtype)

--- a/exdir/core/group.py
+++ b/exdir/core/group.py
@@ -440,8 +440,9 @@ class Group(Object):
                     link_meta[exob.LINK_FILENAME],
                     link_meta[exob.LINK_TARGETNAME])
             else:
-                result = exfile.File(
-                    link_meta[exob.LINK_FILENAME], 'r')[exob.LINK_TARGETNAME]
+                external_file = exfile.File(
+                    link_meta[exob.LINK_FILENAME], 'r')
+                result = external_file[link_meta[exob.LINK_TARGETNAME]]
         return result
 
     def _dataset(self, name):

--- a/exdir/core/group.py
+++ b/exdir/core/group.py
@@ -323,11 +323,12 @@ class Group(Object):
 
 
         # TODO verify proper attributes
-        if not isinstance(data, type(current_object.data)):
-            raise IOError(
-                'Not allowed to change data instance with "require_dataset"'
-                '(existing {} vs new {}), set data if a change is desired.'
-                ''.format(type(current_object.data), type(data)))
+        if any(isinstance(a, pd.DataFrame) for a in [data, current_object.data]):
+            if not isinstance(data, type(current_object.data)):
+                raise IOError(
+                    'Not allowed to require different data instance with'
+                    '(existing {} vs new {}), set data if a change is desired.'
+                    ''.format(type(current_object.data), type(data)))
         if not isinstance(data, pd.DataFrame):
             _assert_data_shape_dtype_match(data, shape, dtype)
             shape, dtype = _data_to_shape_and_dtype(data, shape, dtype)

--- a/exdir/core/links.py
+++ b/exdir/core/links.py
@@ -1,0 +1,58 @@
+from . import exdir_file
+from .exdir_object import Object
+from .constants import *
+
+
+class Link(Object):
+    """
+    Super class for link objects
+    """
+    def __init__(self, path):
+        self.path = path
+
+    @property
+    def _link(self):
+        return {TYPE_METANAME: LINK_TYPENAME}
+
+    def __eq__(self, other):
+        assert self._link.get(LINK_METANAME) == other._link.get(LINK_METANAME)
+
+
+class SoftLink(Link):
+    def __init__(self, path):
+        super(SoftLink, self).__init__(
+            path=path
+        )
+
+    @property
+    def _link(self):
+        result = {
+            TYPE_METANAME: LINK_TYPENAME,
+            LINK_METANAME: {
+                TYPE_METANAME: LINK_SOFTNAME,
+                LINK_TARGETNAME: self.path
+             }
+        }
+        return result
+
+
+class ExternalLink(Link):
+    def __init__(self, other_exdir_path, path):
+        super(ExternalLink, self).__init__(
+            path=path
+        )
+        self.other_exdir_path = other_exdir_path
+        # with exdir_file.File(self.other_exdir_path) as f:
+        #     pass
+
+    @property
+    def _link(self):
+        result = {
+            TYPE_METANAME: LINK_TYPENAME,
+            LINK_METANAME: {
+                TYPE_METANAME: LINK_EXTERNALNAME,
+                LINK_TARGETNAME: self.path,
+                LINK_FILENAME: self.other_exdir_path
+             }
+        }
+        return result

--- a/exdir/core/links.py
+++ b/exdir/core/links.py
@@ -15,7 +15,7 @@ class Link(Object):
         return {TYPE_METANAME: LINK_TYPENAME}
 
     def __eq__(self, other):
-        assert self._link.get(LINK_METANAME) == other._link.get(LINK_METANAME)
+        return self._link.get(LINK_METANAME) == other._link.get(LINK_METANAME)
 
 
 class SoftLink(Link):
@@ -34,6 +34,9 @@ class SoftLink(Link):
              }
         }
         return result
+
+    def __repr__(self):
+        return "Exdir SoftLink '{}' at {}".format(self.path, id(self))
 
 
 class ExternalLink(Link):
@@ -56,3 +59,6 @@ class ExternalLink(Link):
              }
         }
         return result
+
+    def __repr__(self):
+        return "Exdir SoftLink '{}' at {}".format(self.path, id(self))

--- a/exdir/core/links.py
+++ b/exdir/core/links.py
@@ -1,5 +1,12 @@
+try:
+    import pathlib
+except ImportError as e:
+    try:
+        import pathlib2 as pathlib
+    except ImportError:
+        raise e
 from . import exdir_file
-from .exdir_object import Object
+from .exdir_object import Object, is_nonraw_object_directory
 from .constants import *
 
 
@@ -45,8 +52,6 @@ class ExternalLink(Link):
             path=path
         )
         self.filename = filename
-        with exdir_file.File(self.filename) as f:
-            pass
 
     @property
     def _link(self):

--- a/exdir/core/links.py
+++ b/exdir/core/links.py
@@ -40,13 +40,13 @@ class SoftLink(Link):
 
 
 class ExternalLink(Link):
-    def __init__(self, other_exdir_path, path):
+    def __init__(self, filename, path):
         super(ExternalLink, self).__init__(
             path=path
         )
-        self.other_exdir_path = other_exdir_path
-        # with exdir_file.File(self.other_exdir_path) as f:
-        #     pass
+        self.filename = filename
+        with exdir_file.File(self.filename) as f:
+            pass
 
     @property
     def _link(self):
@@ -55,7 +55,7 @@ class ExternalLink(Link):
             LINK_METANAME: {
                 TYPE_METANAME: LINK_EXTERNALNAME,
                 LINK_TARGETNAME: self.path,
-                LINK_FILENAME: self.other_exdir_path
+                LINK_FILENAME: str(self.filename)
              }
         }
         return result

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -235,388 +235,88 @@ def test_compound(setup_teardown_file):
     assert dataframe_equal(dset.data, data)
 
 
-def test_variable_length_string(setup_teardown_file):
-    """Assignement of variable-length byte string produces a fixed-length
-    ascii dataset """
-    f = setup_teardown_file[3]
-    grp = f.create_group("test")
-    values = np.array(['aaaa', 'aaaaaaaa'])
-    data = pd.DataFrame(values)
-
-    dset = grp.create_dataset('foo', data=data)
-    assert dataframe_equal(dset.data, data)
-
-
 def test_variable_length_string_numpy(setup_teardown_file):
     """Assignement of variable-length byte string produces a fixed-length
     ascii dataset """
     f = setup_teardown_file[3]
     grp = f.create_group("test")
-    data = np.array(['aaaa', 'aaaaaaaa'])
-    # with pytest.raises(IOError):
-    grp.create_dataset('foo', data=data)
+    # unable to change length of string with setitem
+    data = np.array(['a', 'aa'])
+    dset = grp.create_dataset('foo', data=data)
+    dset[1] = 'aaaaaa'
+    assert np.array_equal(dset.data, data)
+
+# sjekk at setterne faktisk endrer på fil
+def test_variable_length_string_df(setup_teardown_file):
+    """Assignement of variable-length byte string produces a fixed-length
+    ascii dataset """
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+    # one needs object dtype in order to be able to change length of string with setitem
+    values = ['a', 'aa']
+    data = pd.DataFrame(values).T
+    dset = grp.create_dataset('foo', data=data)
+
+    dset['1'] = 'aaaaaa'
+    values[1] = 'aaaaaa'
+    assert np.array_equal(dset.data.values[0], values)
+    dset._reload_data()
+    assert np.array_equal(dset.data.values[0], values)
 
 
-#
-# # Feature: Dataset dtype is available as .dtype property
-#
-# def test_dtype(setup_teardown_file):
-#     """Retrieve dtype from dataset."""
-#     f = setup_teardown_file[3]
-#     grp = f.create_group("test")
-#
-#     dset = grp.create_dataset('foo', (5,), '|S10')
-#     assert dset.dtype == np.dtype('|S10')
-#
-#
-# # Feature: Size of first axis is available via Python's len
-# def test_len(setup_teardown_file):
-#     """len()."""
-#     f = setup_teardown_file[3]
-#     grp = f.create_group("test")
-#
-#     dset = grp.create_dataset('foo', (312, 15))
-#     assert len(dset) == 312
-#
-#
-# def test_len_scalar(setup_teardown_file):
-#     """len()  of scalar)."""
-#     f = setup_teardown_file[3]
-#     grp = f.create_group("test")
-#
-#     dset =grp.create_dataset('foo', data=1)
-#     with pytest.raises(TypeError):
-#         len(dset)
-#
-#
-# # Feature: Iterating over a dataset yields rows
-#
-# def test_iter(setup_teardown_file):
-#     """Iterating over a dataset yields rows."""
-#     f = setup_teardown_file[3]
-#     grp = f.create_group("test")
-#
-#     data = np.arange(30, dtype='f').reshape((10, 3))
-#     dset = grp.create_dataset('foo', data=data)
-#     for x, y in zip(dset, data):
-#         assert len(x) == 3
-#         assert np.array_equal(x, y)
-#
-#
-# def test_iter_scalar(setup_teardown_file):
-#     """Iterating over scalar dataset raises TypeError."""
-#     f = setup_teardown_file[3]
-#     grp = f.create_group("test")
-#
-#     dset = grp.create_dataset('foo', shape=())
-#     with pytest.raises(TypeError):
-#         [x for x in dset]
-#
-#
-# def test_trailing_slash(setup_teardown_file):
-#     """Trailing slashes are unconditionally ignored."""
-#     f = setup_teardown_file[3]
-#
-#     f["dataset"] = 42
-#     assert "dataset/" in  f
-#
-#
-# # Feature: Compound types correctly round-trip
-# def test_compund(setup_teardown_file):
-#     """Compound types are read back in correct order."""
-#     f = setup_teardown_file[3]
-#     grp = f.create_group("test")
-#
-#     dt = np.dtype( [('weight', np.float64),
-#                     ('cputime', np.float64),
-#                     ('walltime', np.float64),
-#                     ('parents_offset', np.uint32),
-#                     ('n_parents', np.uint32),
-#                     ('status', np.uint8),
-#                     ('endpoint_type', np.uint8)])
-#
-#     testdata = np.ndarray((16,), dtype=dt)
-#     for key in dt.fields:
-#         testdata[key] = np.random.random((16,))*100
-#
-#     # print(testdata)
-#
-#     grp['test'] = testdata
-#     outdata = grp['test'][()]
-#     assert np.all(outdata == testdata)
-#     assert outdata.dtype == testdata.dtype
-#
-# def test_assign(setup_teardown_file):
-#     f = setup_teardown_file[3]
-#     grp = f.create_group("test")
-#
-#     dt = np.dtype([('weight', (np.float64, 3)),
-#                    ('endpoint_type', np.uint8),])
-#
-#     testdata = np.ndarray((16,), dtype=dt)
-#     for key in dt.fields:
-#         testdata[key] = np.random.random(size=testdata[key].shape)*100
-#
-#     ds = grp.create_dataset('test', (16,), dtype=dt)
-#     for key in dt.fields:
-#         ds[key] = testdata[key]
-#
-#     outdata = f['test']["test"][()]
-#
-#     assert np.all(outdata == testdata)
-#     assert outdata.dtype == testdata.dtype
-#
-#
-#
-#
-# def test_set_data(setup_teardown_file):
-#     """Set data works correctly."""
-#     f = setup_teardown_file[3]
-#     grp = f.create_group("test")
-#
-#     testdata = np.ones((10, 2))
-#     grp['testdata'] = testdata
-#     outdata = grp['testdata'][()]
-#     assert np.all(outdata == testdata)
-#     assert outdata.dtype == testdata.dtype
-#
-#     grp['testdata'] = testdata
-#
-#
-#
-#
-# def test_eq_false(setup_teardown_file):
-#     """__eq__."""
-#     f = setup_teardown_file[3]
-#     grp = f.create_group("test")
-#
-#     dset = grp.create_dataset('foo', data=1)
-#     dset2 = grp.create_dataset('foobar', (2, 2))
-#
-#     assert dset != dset2
-#     assert not dset == 2
-#
-# def test_eq(setup_teardown_file):
-#     """__eq__."""
-#     f = setup_teardown_file[3]
-#     grp = f.create_group("test")
-#
-#     dset = grp.create_dataset('foo', data=np.ones((2, 2)))
-#
-#     assert dset == dset
-#
-#
-# def test_mmap(setup_teardown_file):
-#     """Test that changes to a mmap loaded numpy file is written to disk"""
-#     f = setup_teardown_file[3]
-#     grp = f.create_group("test")
-#
-#     dset = grp.create_dataset('foo', (10**3, 10**3), fillvalue=2)
-#     dset[1, 1] = 100
-#
-#     tmp_file = np.load(str(setup_teardown_file[1] / "test" / "foo" / "data.npy"))
-#
-#     assert dset.data[1, 1] == 100
-#     assert tmp_file[1, 1] == 100
-#
-#
-# def test_modify_view(setup_teardown_file):
-#     f = setup_teardown_file[3]
-#     dataset = f.create_dataset("mydata", data=np.array([1, 2, 3, 4, 5, 6, 7, 8]))
-#     dataset[3:5] = np.array([8, 9])
-#     assert np.array_equal(f["mydata"][3:5], np.array([8, 9]))
-#     view = dataset[3:5]
-#     view[0] = 10
-#     assert f["mydata"][3] == 10
-#
-#
-# def test_single_index(setup_teardown_file):
-#     """Single-element selection with [index] yields array scalar."""
-#     f = setup_teardown_file[3]
-#     dset = f.create_dataset('x', (1,), dtype='i1')
-#     out = dset[0]
-#     assert isinstance(out, np.int8)
-#
-# def test_single_null(setup_teardown_file):
-#     """Single-element selection with [()] yields ndarray."""
-#     f = setup_teardown_file[3]
-#
-#     dset = f.create_dataset('x', (1,), dtype='i1')
-#     out = dset[()]
-#     assert isinstance(out, np.ndarray)
-#     assert out.shape == (1,)
-#
-# def test_scalar_index(setup_teardown_file):
-#     """Slicing with [...] yields scalar ndarray."""
-#     f = setup_teardown_file[3]
-#
-#     dset = f.create_dataset('x', shape=(), dtype='f')
-#     out = dset[...]
-#     assert isinstance(out, np.ndarray)
-#     assert out.shape == ()
-#
-# def test_scalar_null(setup_teardown_file):
-#     """Slicing with [()] yields array scalar."""
-#     f = setup_teardown_file[3]
-#
-#     dset = f.create_dataset('x', shape=(), dtype='i1')
-#     out = dset[()]
-#
-#     assert out.dtype == "int8"
-#
-# def test_compound_index(setup_teardown_file):
-#     """Compound scalar is numpy.void, not tuple."""
-#     f = setup_teardown_file[3]
-#
-#     dt = np.dtype([('a', 'i4'), ('b', 'f8')])
-#     v = np.ones((4,), dtype=dt)
-#     dset = f.create_dataset('foo', (4,), data=v)
-#     assert dset[0] == v[0]
-#     assert isinstance(dset[0], np.void)
-#
-#
-# # Feature: Simple NumPy-style slices (start:stop:step) are supported.
-#
-# def test_negative_stop(setup_teardown_file):
-#     """Negative stop indexes work as they do in NumPy."""
-#     f = setup_teardown_file[3]
-#
-#     arr = np.arange(10)
-#     dset = f.create_dataset('x', data=arr)
-#
-#     assert np.array_equal(dset[2:-2], arr[2:-2])
-#
-#
-# # Feature: Array types are handled appropriately
-#
-# def test_read(setup_teardown_file):
-#     """Read arrays tack array dimensions onto end of shape tuple."""
-#     f = setup_teardown_file[3]
-#
-#     dt = np.dtype('(3,)f8')
-#     dset = f.create_dataset('x', (10,), dtype=dt)
-#     # TODO implement this
-#     # assert dset.shape == (10,)
-#     # assert dset.dtype == dt
-#
-#     # Full read
-#     out = dset[...]
-#     assert out.dtype == np.dtype('f8')
-#     assert out.shape == (10, 3)
-#
-#     # Single element
-#     out = dset[0]
-#     assert out.dtype == np.dtype('f8')
-#     assert out.shape == (3,)
-#
-#     # Range
-#     out = dset[2:8:2]
-#     assert out.dtype == np.dtype('f8')
-#     assert out.shape == (3, 3)
-#
-# def test_write_broadcast(setup_teardown_file):
-#     """Array fill from constant is  supported."""
-#     f = setup_teardown_file[3]
-#
-#     dt = np.dtype('(3,)i')
-#
-#     dset = f.create_dataset('x', (10,), dtype=dt)
-#     dset[...] = 42
-#
-#
-#
-# def test_write_element(setup_teardown_file):
-#     """Write a single element to the array."""
-#     f = setup_teardown_file[3]
-#
-#     dt = np.dtype('(3,)f8')
-#     dset = f.create_dataset('x', (10,), dtype=dt)
-#
-#     data = np.array([1, 2, 3.0])
-#     dset[4] = data
-#
-#     out = dset[4]
-#     assert np.all(out == data)
-#
-#
-# def test_write_slices(setup_teardown_file):
-#     """Write slices to array type."""
-#     f = setup_teardown_file[3]
-#
-#     dt = np.dtype('(3,)i')
-#
-#     data1 = np.ones((2, ), dtype=dt)
-#     data2 = np.ones((4, 5), dtype=dt)
-#
-#     dset = f.create_dataset('x', (10, 9, 11), dtype=dt)
-#
-#     dset[0, 0, 2:4] = data1
-#     assert np.array_equal(dset[0, 0, 2:4], data1)
-#
-#     dset[3, 1:5, 6:11] = data2
-#     assert np.array_equal(dset[3, 1:5, 6:11], data2)
-#
-#
-# def test_roundtrip(setup_teardown_file):
-#     """Read the contents of an array and write them back."""
-#     f = setup_teardown_file[3]
-#     dt = np.dtype('(3,)f8')
-#     dset = f.create_dataset('x', (10,), dtype=dt)
-#
-#     out = dset[...]
-#     dset[...] = out
-#
-#     assert np.all(dset[...] == out)
-#
-#
-#
-# # Feature Slices resulting in empty arrays
-#
-#
-# def test_slice_zero_length_dimension(setup_teardown_file):
-#     """Slice a dataset with a zero in its shape vector
-#        along the zero-length dimension."""
-#     f = setup_teardown_file[3]
-#
-#     for i, shape in enumerate([(0,), (0, 3), (0, 2, 1)]):
-#         dset = f.create_dataset('x%d'%i, shape, dtype=np.int)
-#         assert dset.shape == shape
-#         out = dset[...]
-#         assert isinstance(out, np.ndarray)
-#         assert out.shape == shape
-#         out = dset[:]
-#         assert isinstance(out, np.ndarray)
-#         assert out.shape == shape
-#         if len(shape) > 1:
-#             out = dset[:, :1]
-#             assert isinstance(out, np.ndarray)
-#             assert out.shape[:2] == (0, 1)
-#
-# def test_slice_other_dimension(setup_teardown_file):
-#     """Slice a dataset with a zero in its shape vector
-#        along a non-zero-length dimension."""
-#     f = setup_teardown_file[3]
-#
-#     for i, shape in enumerate([(3, 0), (1, 2, 0), (2, 0, 1)]):
-#         dset = f.create_dataset('x%d'%i, shape, dtype=np.int)
-#         assert dset.shape == shape
-#         out = dset[:1]
-#         assert isinstance(out, np.ndarray)
-#         assert out.shape == (1,)+shape[1:]
-#
-# def test_slice_of_length_zero(setup_teardown_file):
-#     """Get a slice of length zero from a non-empty dataset."""
-#     f = setup_teardown_file[3]
-#
-#     for i, shape in enumerate([(3, ), (2, 2, ), (2,  1, 5)]):
-#         dset = f.create_dataset('x%d'%i, data=np.zeros(shape, np.int))
-#         assert dset.shape == shape
-#         out = dset[1:1]
-#         assert isinstance(out, np.ndarray)
-#         assert out.shape == (0,)+shape[1:]
-#
-# def test_modify_all(setup_teardown_file):
-#     f = setup_teardown_file[3]
-#     dset = f.create_dataset("test", data=np.arange(10))
-#     dset.data = np.ones(4)
-#     assert np.all(dset.data == np.ones(4))
+def test_flush(setup_teardown_file):
+    """Assignement of variable-length byte string produces a fixed-length
+    ascii dataset """
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+    # one needs object dtype in order to be able to change length of string with setitem
+    values = ['a', 'aa']
+    data = pd.DataFrame(values).T
+    dset = grp.create_dataset('foo', data=data)
+    # using iloc changes data only in memory
+    values[1] = 'aaaaaa'
+    dset.data.iloc[0,1] = 'aaaaaa'
+    assert np.array_equal(dset.data.values[0], values)
+    dset._reload_data()
+    assert dataframe_equal(dset.data, data)
+    # flush saves data to file
+    dset.data.iloc[0,1] = 'aaaaaa'
+    dset.flush()
+    dset._reload_data()
+    assert np.array_equal(dset.data.values[0], values)
+
+
+# Feature: Size of first axis is available via Python's len
+def test_len(setup_teardown_file):
+    """len()."""
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+    data = pd.DataFrame(np.zeros((3, 10)))
+    dset = grp.require_dataset('bar', data=data)
+    assert len(dset) == 3
+
+# Feature: Iterating over a dataset yields index keys
+
+def test_iter(setup_teardown_file):
+    """Iterating over a dataset yields rows."""
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+
+    values = np.arange(30, dtype='f').reshape((10, 3))
+    data = pd.DataFrame(values)
+    dset = grp.create_dataset('foo', data=data)
+    for x, y in zip(dset, data):
+        assert x == str(y) # NOTE feather converts int names to str
+
+
+def test_set_data(setup_teardown_file):
+    """Set data works correctly."""
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+
+    testdata = pd.DataFrame(np.ones((10, 2)))
+    grp['testdata'] = testdata
+    outdata = grp['testdata'].data
+    assert dataframe_equal(testdata, outdata)
+
+    grp['testdata'] = testdata

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1,0 +1,608 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Exdir, the Experimental Directory Structure.
+#
+# Copyright 2017 Simen Tennøe
+#
+# License: MIT, see "LICENSE" file for the full license terms.
+#
+# This file contains code from h5py, a Python interface to the HDF5 library,
+# licensed under a standard 3-clause BSD license
+# with copyright Andrew Collette and contributors.
+# See http://www.h5py.org and the "3rdparty/h5py-LICENSE" file for details.
+
+
+import pytest
+import numpy as np
+import pandas as pd
+import os
+
+from exdir.core import Attribute, File, Dataset
+
+# TODO add the code below for testing true equality when parallelizing
+# def __eq__(self, other):
+# self[:]
+# if isinstance(other, self.__class__):
+#     other[:]
+#     if self.__dict__.keys() != other.__dict__.keys():
+#         return False
+#
+#     for key in self.__dict__:
+#         if key == "_data":
+#             if not np.array_equal(self.__dict__["_data"], other.__dict__["_data"]):
+#                 return False
+#         else:
+#             if self.__dict__[key] != other.__dict__[key]:
+#                 return False
+#     return True
+# else:
+#     return False
+
+
+# Feature: Datasets can be created from a shape only
+
+def test_create_empty(setup_teardown_file):
+    """Create a scalar dataset."""
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+    data = pd.DataFrame([])
+    dset = grp.create_dataset('foo', data=data)
+    assert dset.shape == (0,0)
+    assert dset.data.equals(data)
+
+
+def test_create_scalar(setup_teardown_file):
+    """Create a size-1 dataset."""
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+    data = pd.DataFrame([1])
+    dset = grp.create_dataset('foo', data=data)
+    assert dset.shape == (1,1)
+    assert dset.shape == dset.data.shape
+    assert data.values == dset.data.values
+
+
+def test_create_extended(setup_teardown_file):
+    """Create an extended dataset."""
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+    data = pd.DataFrame(np.arange(63))
+    dset = grp.create_dataset('foo', data=data)
+    assert dset.shape == (63,1)
+    assert dset.size == 63
+
+    data = pd.DataFrame(np.zeros((6,10)))
+    dset = f.create_dataset('bar', data=data)
+    assert dset.shape == (6, 10)
+    assert dset.size == (60)
+
+
+def test_no_dtype(setup_teardown_file):
+    """Confirm that datafram has no dtype."""
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+
+    data = pd.DataFrame(np.zeros((6,10)))
+    dset = f.create_dataset('bar', data=data)
+    with pytest.raises(AttributeError):
+        dset.dtype
+
+
+def test_no_dtype_create(setup_teardown_file):
+    """Confirm that one can force dtype """
+    f = setup_teardown_file[3]
+    data = pd.DataFrame(np.zeros((6,10)))
+    with pytest.raises(NotImplementedError):
+        f.create_dataset('bar', data=data, dtype=np.int16)
+
+
+def test_numpy_then_dataframe(setup_teardown_file):
+    """Confirm that datafram has no dtype."""
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+
+    data = pd.DataFrame(np.zeros((6,10)))
+    dset = f.create_dataset('bar', (6,10))
+    assert isinstance(f['bar'].data, np.ndarray)
+    f['bar'] = data
+    assert np.array_equal(f['bar'].data.values, data.values)
+    assert isinstance(f['bar'].data, pd.DataFrame)
+    assert not (dset.directory / 'data.npy').exists()
+
+
+def test_datafram_then_numpy(setup_teardown_file):
+    """Confirm that datafram has no dtype."""
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+
+    data = pd.DataFrame(np.zeros((6,10)))
+    dset = f.create_dataset('bar', data=data)
+    assert isinstance(f['bar'].data, pd.DataFrame)
+    f['bar'] = np.zeros((6,10))
+    assert np.array_equal(f['bar'].data, np.zeros((6,10)))
+    assert isinstance(f['bar'].data, np.ndarray)
+    assert not (dset.directory / 'data.feather').exists()
+
+
+def test_reshape(setup_teardown_file):
+    """Create from existing data, and make it fit a new shape."""
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+
+    data = pd.DataFrame(np.zeros((6,10)))
+    with pytest.raises(NotImplementedError):
+        dset = grp.create_dataset('foo', shape=(10, 3), data=data)
+
+# # Feature: Datasets can be created only if they don't exist in the file
+def test_create(setup_teardown_file):
+    """Create new dataset with no conflicts."""
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+
+    data = pd.DataFrame(np.zeros((10, 3)))
+    dset = grp.require_dataset('foo', (10, 3))
+    assert isinstance(dset, Dataset)
+    assert dset.shape == (10, 3)
+
+
+def test_create_existing(setup_teardown_file):
+    """require_dataset yields existing dataset."""
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+
+    data2 = pd.DataFrame(np.zeros((3, 10)))
+    data3 = pd.DataFrame(np.zeros((4, 11)))
+    dset2 = grp.require_dataset('bar', data=data2)
+    dset3 = grp.require_dataset('bar', data=data3)
+    assert isinstance(dset2, Dataset)
+    assert np.array_equal(dset2.data.values, data2.values)
+    assert np.array_equal(dset3.data.values, data2.values)
+    assert dset2 == dset3
+#
+#
+# def test_shape_conflict(setup_teardown_file):
+#     """require_dataset with shape conflict yields TypeError."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     grp.create_dataset('foo', (10, 3), 'f')
+#     with pytest.raises(TypeError):
+#         grp.require_dataset('foo', (10, 4), 'f')
+#
+#
+# def test_type_confict(setup_teardown_file):
+#     """require_dataset with object type conflict yields TypeError."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     grp.create_group('foo')
+#     with pytest.raises(TypeError):
+#         grp.require_dataset('foo', (10, 3), 'f')
+#
+#
+# def test_dtype_conflict(setup_teardown_file):
+#     """require_dataset with dtype conflict (strict mode) yields TypeError."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dset = grp.create_dataset('foo', (10, 3), 'f')
+#     with pytest.raises(TypeError):
+#         grp.require_dataset('foo', (10, 3), 'S10')
+#
+#
+# def test_dtype_close(setup_teardown_file):
+#     """require_dataset with convertible type succeeds (non-strict mode)-"""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dset = grp.create_dataset('foo', (10, 3), 'i4')
+#     dset2 = grp.require_dataset('foo', (10, 3), 'i2', exact=False)
+#     assert dset == dset2
+#     assert dset2.dtype == np.dtype('i4')
+#
+#
+# # Feature: Datasets can be created with fill value
+#
+# def test_create_fillval(setup_teardown_file):
+#     """Fill value is reflected in dataset contents."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dset = grp.create_dataset('foo', (10,), fillvalue=4.0)
+#     assert dset[0] == 4.0
+#     assert dset[7] == 4.0
+#
+#
+#
+# def test_compound(setup_teardown_file):
+#     """Fill value works with compound types."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dt = np.dtype([('a', 'f4'), ('b', 'i8')])
+#     v = np.ones((1,), dtype=dt)[0]
+#     dset = grp.create_dataset('foo', (10,), dtype=dt, fillvalue=v)
+#
+#
+# def test_exc(setup_teardown_file):
+#     """Bogus fill value raises TypeError."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     with pytest.raises(TypeError):
+#         grp.create_dataset('foo', (10,), dtype="float32", fillvalue={"a": 2})
+#
+#
+# def test_string(setup_teardown_file):
+#     """Assignement of fixed-length byte string produces a fixed-length
+#     ascii dataset """
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dset = grp.create_dataset('foo', data="string")
+#     assert dset.data == "string"
+#
+#
+#
+# # Feature: Dataset dtype is available as .dtype property
+#
+# def test_dtype(setup_teardown_file):
+#     """Retrieve dtype from dataset."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dset = grp.create_dataset('foo', (5,), '|S10')
+#     assert dset.dtype == np.dtype('|S10')
+#
+#
+# # Feature: Size of first axis is available via Python's len
+# def test_len(setup_teardown_file):
+#     """len()."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dset = grp.create_dataset('foo', (312, 15))
+#     assert len(dset) == 312
+#
+#
+# def test_len_scalar(setup_teardown_file):
+#     """len()  of scalar)."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dset =grp.create_dataset('foo', data=1)
+#     with pytest.raises(TypeError):
+#         len(dset)
+#
+#
+# # Feature: Iterating over a dataset yields rows
+#
+# def test_iter(setup_teardown_file):
+#     """Iterating over a dataset yields rows."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     data = np.arange(30, dtype='f').reshape((10, 3))
+#     dset = grp.create_dataset('foo', data=data)
+#     for x, y in zip(dset, data):
+#         assert len(x) == 3
+#         assert np.array_equal(x, y)
+#
+#
+# def test_iter_scalar(setup_teardown_file):
+#     """Iterating over scalar dataset raises TypeError."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dset = grp.create_dataset('foo', shape=())
+#     with pytest.raises(TypeError):
+#         [x for x in dset]
+#
+#
+# def test_trailing_slash(setup_teardown_file):
+#     """Trailing slashes are unconditionally ignored."""
+#     f = setup_teardown_file[3]
+#
+#     f["dataset"] = 42
+#     assert "dataset/" in  f
+#
+#
+# # Feature: Compound types correctly round-trip
+# def test_compund(setup_teardown_file):
+#     """Compound types are read back in correct order."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dt = np.dtype( [('weight', np.float64),
+#                     ('cputime', np.float64),
+#                     ('walltime', np.float64),
+#                     ('parents_offset', np.uint32),
+#                     ('n_parents', np.uint32),
+#                     ('status', np.uint8),
+#                     ('endpoint_type', np.uint8)])
+#
+#     testdata = np.ndarray((16,), dtype=dt)
+#     for key in dt.fields:
+#         testdata[key] = np.random.random((16,))*100
+#
+#     # print(testdata)
+#
+#     grp['test'] = testdata
+#     outdata = grp['test'][()]
+#     assert np.all(outdata == testdata)
+#     assert outdata.dtype == testdata.dtype
+#
+# def test_assign(setup_teardown_file):
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dt = np.dtype([('weight', (np.float64, 3)),
+#                    ('endpoint_type', np.uint8),])
+#
+#     testdata = np.ndarray((16,), dtype=dt)
+#     for key in dt.fields:
+#         testdata[key] = np.random.random(size=testdata[key].shape)*100
+#
+#     ds = grp.create_dataset('test', (16,), dtype=dt)
+#     for key in dt.fields:
+#         ds[key] = testdata[key]
+#
+#     outdata = f['test']["test"][()]
+#
+#     assert np.all(outdata == testdata)
+#     assert outdata.dtype == testdata.dtype
+#
+#
+#
+#
+# def test_set_data(setup_teardown_file):
+#     """Set data works correctly."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     testdata = np.ones((10, 2))
+#     grp['testdata'] = testdata
+#     outdata = grp['testdata'][()]
+#     assert np.all(outdata == testdata)
+#     assert outdata.dtype == testdata.dtype
+#
+#     grp['testdata'] = testdata
+#
+#
+#
+#
+# def test_eq_false(setup_teardown_file):
+#     """__eq__."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dset = grp.create_dataset('foo', data=1)
+#     dset2 = grp.create_dataset('foobar', (2, 2))
+#
+#     assert dset != dset2
+#     assert not dset == 2
+#
+# def test_eq(setup_teardown_file):
+#     """__eq__."""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dset = grp.create_dataset('foo', data=np.ones((2, 2)))
+#
+#     assert dset == dset
+#
+#
+# def test_mmap(setup_teardown_file):
+#     """Test that changes to a mmap loaded numpy file is written to disk"""
+#     f = setup_teardown_file[3]
+#     grp = f.create_group("test")
+#
+#     dset = grp.create_dataset('foo', (10**3, 10**3), fillvalue=2)
+#     dset[1, 1] = 100
+#
+#     tmp_file = np.load(str(setup_teardown_file[1] / "test" / "foo" / "data.npy"))
+#
+#     assert dset.data[1, 1] == 100
+#     assert tmp_file[1, 1] == 100
+#
+#
+# def test_modify_view(setup_teardown_file):
+#     f = setup_teardown_file[3]
+#     dataset = f.create_dataset("mydata", data=np.array([1, 2, 3, 4, 5, 6, 7, 8]))
+#     dataset[3:5] = np.array([8, 9])
+#     assert np.array_equal(f["mydata"][3:5], np.array([8, 9]))
+#     view = dataset[3:5]
+#     view[0] = 10
+#     assert f["mydata"][3] == 10
+#
+#
+# def test_single_index(setup_teardown_file):
+#     """Single-element selection with [index] yields array scalar."""
+#     f = setup_teardown_file[3]
+#     dset = f.create_dataset('x', (1,), dtype='i1')
+#     out = dset[0]
+#     assert isinstance(out, np.int8)
+#
+# def test_single_null(setup_teardown_file):
+#     """Single-element selection with [()] yields ndarray."""
+#     f = setup_teardown_file[3]
+#
+#     dset = f.create_dataset('x', (1,), dtype='i1')
+#     out = dset[()]
+#     assert isinstance(out, np.ndarray)
+#     assert out.shape == (1,)
+#
+# def test_scalar_index(setup_teardown_file):
+#     """Slicing with [...] yields scalar ndarray."""
+#     f = setup_teardown_file[3]
+#
+#     dset = f.create_dataset('x', shape=(), dtype='f')
+#     out = dset[...]
+#     assert isinstance(out, np.ndarray)
+#     assert out.shape == ()
+#
+# def test_scalar_null(setup_teardown_file):
+#     """Slicing with [()] yields array scalar."""
+#     f = setup_teardown_file[3]
+#
+#     dset = f.create_dataset('x', shape=(), dtype='i1')
+#     out = dset[()]
+#
+#     assert out.dtype == "int8"
+#
+# def test_compound_index(setup_teardown_file):
+#     """Compound scalar is numpy.void, not tuple."""
+#     f = setup_teardown_file[3]
+#
+#     dt = np.dtype([('a', 'i4'), ('b', 'f8')])
+#     v = np.ones((4,), dtype=dt)
+#     dset = f.create_dataset('foo', (4,), data=v)
+#     assert dset[0] == v[0]
+#     assert isinstance(dset[0], np.void)
+#
+#
+# # Feature: Simple NumPy-style slices (start:stop:step) are supported.
+#
+# def test_negative_stop(setup_teardown_file):
+#     """Negative stop indexes work as they do in NumPy."""
+#     f = setup_teardown_file[3]
+#
+#     arr = np.arange(10)
+#     dset = f.create_dataset('x', data=arr)
+#
+#     assert np.array_equal(dset[2:-2], arr[2:-2])
+#
+#
+# # Feature: Array types are handled appropriately
+#
+# def test_read(setup_teardown_file):
+#     """Read arrays tack array dimensions onto end of shape tuple."""
+#     f = setup_teardown_file[3]
+#
+#     dt = np.dtype('(3,)f8')
+#     dset = f.create_dataset('x', (10,), dtype=dt)
+#     # TODO implement this
+#     # assert dset.shape == (10,)
+#     # assert dset.dtype == dt
+#
+#     # Full read
+#     out = dset[...]
+#     assert out.dtype == np.dtype('f8')
+#     assert out.shape == (10, 3)
+#
+#     # Single element
+#     out = dset[0]
+#     assert out.dtype == np.dtype('f8')
+#     assert out.shape == (3,)
+#
+#     # Range
+#     out = dset[2:8:2]
+#     assert out.dtype == np.dtype('f8')
+#     assert out.shape == (3, 3)
+#
+# def test_write_broadcast(setup_teardown_file):
+#     """Array fill from constant is  supported."""
+#     f = setup_teardown_file[3]
+#
+#     dt = np.dtype('(3,)i')
+#
+#     dset = f.create_dataset('x', (10,), dtype=dt)
+#     dset[...] = 42
+#
+#
+#
+# def test_write_element(setup_teardown_file):
+#     """Write a single element to the array."""
+#     f = setup_teardown_file[3]
+#
+#     dt = np.dtype('(3,)f8')
+#     dset = f.create_dataset('x', (10,), dtype=dt)
+#
+#     data = np.array([1, 2, 3.0])
+#     dset[4] = data
+#
+#     out = dset[4]
+#     assert np.all(out == data)
+#
+#
+# def test_write_slices(setup_teardown_file):
+#     """Write slices to array type."""
+#     f = setup_teardown_file[3]
+#
+#     dt = np.dtype('(3,)i')
+#
+#     data1 = np.ones((2, ), dtype=dt)
+#     data2 = np.ones((4, 5), dtype=dt)
+#
+#     dset = f.create_dataset('x', (10, 9, 11), dtype=dt)
+#
+#     dset[0, 0, 2:4] = data1
+#     assert np.array_equal(dset[0, 0, 2:4], data1)
+#
+#     dset[3, 1:5, 6:11] = data2
+#     assert np.array_equal(dset[3, 1:5, 6:11], data2)
+#
+#
+# def test_roundtrip(setup_teardown_file):
+#     """Read the contents of an array and write them back."""
+#     f = setup_teardown_file[3]
+#     dt = np.dtype('(3,)f8')
+#     dset = f.create_dataset('x', (10,), dtype=dt)
+#
+#     out = dset[...]
+#     dset[...] = out
+#
+#     assert np.all(dset[...] == out)
+#
+#
+#
+# # Feature Slices resulting in empty arrays
+#
+#
+# def test_slice_zero_length_dimension(setup_teardown_file):
+#     """Slice a dataset with a zero in its shape vector
+#        along the zero-length dimension."""
+#     f = setup_teardown_file[3]
+#
+#     for i, shape in enumerate([(0,), (0, 3), (0, 2, 1)]):
+#         dset = f.create_dataset('x%d'%i, shape, dtype=np.int)
+#         assert dset.shape == shape
+#         out = dset[...]
+#         assert isinstance(out, np.ndarray)
+#         assert out.shape == shape
+#         out = dset[:]
+#         assert isinstance(out, np.ndarray)
+#         assert out.shape == shape
+#         if len(shape) > 1:
+#             out = dset[:, :1]
+#             assert isinstance(out, np.ndarray)
+#             assert out.shape[:2] == (0, 1)
+#
+# def test_slice_other_dimension(setup_teardown_file):
+#     """Slice a dataset with a zero in its shape vector
+#        along a non-zero-length dimension."""
+#     f = setup_teardown_file[3]
+#
+#     for i, shape in enumerate([(3, 0), (1, 2, 0), (2, 0, 1)]):
+#         dset = f.create_dataset('x%d'%i, shape, dtype=np.int)
+#         assert dset.shape == shape
+#         out = dset[:1]
+#         assert isinstance(out, np.ndarray)
+#         assert out.shape == (1,)+shape[1:]
+#
+# def test_slice_of_length_zero(setup_teardown_file):
+#     """Get a slice of length zero from a non-empty dataset."""
+#     f = setup_teardown_file[3]
+#
+#     for i, shape in enumerate([(3, ), (2, 2, ), (2,  1, 5)]):
+#         dset = f.create_dataset('x%d'%i, data=np.zeros(shape, np.int))
+#         assert dset.shape == shape
+#         out = dset[1:1]
+#         assert isinstance(out, np.ndarray)
+#         assert out.shape == (0,)+shape[1:]
+#
+# def test_modify_all(setup_teardown_file):
+#     f = setup_teardown_file[3]
+#     dset = f.create_dataset("test", data=np.arange(10))
+#     dset.data = np.ones(4)
+#     assert np.all(dset.data == np.ones(4))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -171,6 +171,17 @@ def test_shape_conflict(setup_teardown_file):
         grp.require_dataset('foo', (10, 4), 'f')
 
 
+def test_create_dtype_object(setup_teardown_file):
+    """Assignement of variable-length byte string produces a fixed-length
+    ascii dataset """
+    f = setup_teardown_file[3]
+    grp = f.create_group("test")
+    # one needs object dtype in order to be able to change length of string with setitem
+    data = np.array(['aaaa', 'aaaaa'], dtype=object)
+    with pytest.raises(ValueError):
+        grp.create_dataset('foo', data=data)
+
+
 def test_type_confict(setup_teardown_file):
     """require_dataset with object type conflict yields TypeError."""
     f = setup_teardown_file[3]

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -96,32 +96,29 @@ def test_exc(setup_teardown_file):
 # Feature: Create and manage external links
 def test_external_path(setup_teardown_file):
     """ External link paths attributes """
-    g = File(setup_teardown_file[0] / 'foo.exdir', 'w')
+    external_path = setup_teardown_file[0] / 'foo.exdir'
+    g = File(external_path, 'w')
     egrp = g.create_group('foo')
-    el = ExternalLink(setup_teardown_file[0] / 'foo.exdir', '/foo')
-    assert el.filename == 'foo.exdir'
+    el = ExternalLink(external_path, '/foo')
+    assert el.filename == external_path
     assert el.path == '/foo'
-
-
-def test_external_must_exist(setup_teardown_file):
-    """ External link paths attributes """
-    with pytest.raises(FileExistsError):
-        el = ExternalLink('foo.exdir', '/foo')
 
 
 def test_external_repr(setup_teardown_file):
     """ External link repr """
-    g = File(setup_teardown_file[0] / 'foo.exdir', 'w')
-    el = ExternalLink(setup_teardown_file[0] / 'foo.exdir', '/foo')
+    external_path = setup_teardown_file[0] / 'foo.exdir'
+    g = File(external_path, 'w')
+    el = ExternalLink(external_path, '/foo')
     assert isinstance(repr(el), str)
 
 
 def test_create(setup_teardown_file):
     """ Creating external links """
+    external_path = setup_teardown_file[0] / 'foo.exdir'
     f = setup_teardown_file[3]
-    g = File(setup_teardown_file[0] / 'foo.exdir', 'w')
+    g = File(external_path, 'w')
     egrp = g.require_group('external')
-    f['ext'] = ExternalLink(setup_teardown_file[0] / 'foo.exdir', '/external')
+    f['ext'] = ExternalLink(external_path, '/external')
     grp = f['ext']
     ef = grp.file
     assert ef != f
@@ -130,63 +127,64 @@ def test_create(setup_teardown_file):
 
 def test_broken_external_link(setup_teardown_file):
     """ KeyError raised when attempting to open broken link """
+    external_path = setup_teardown_file[0] / 'foo.exdir'
     f = setup_teardown_file[3]
-    g = File(setup_teardown_file[0] / 'foo.exdir', 'w')
-    f['ext'] = ExternalLink(setup_teardown_file[0] / 'foo.exdir', '/missing')
+    g = File(external_path, 'w')
+    f['ext'] = ExternalLink(external_path, '/missing')
     with pytest.raises(KeyError):
         f['ext']
-#
-# # I would prefer IOError but there's no way to fix this as the exception
-# # class is determined by HDF5.
-# def test_exc_missingfile(setup_teardown_file):
-#     """ KeyError raised when attempting to open missing file """
-#     f['ext'] = ExternalLink('mongoose.exdir','/foo')
-#     with assertRaises(KeyError):
-#         f['ext']
-#
-# def test_close_file(setup_teardown_file):
-#     """ Files opened by accessing external links can be closed
-#     Issue 189.
-#     """
-#     f['ext'] = ExternalLink(ename, '/')
-#     grp = f['ext']
-#     f2 = grp.file
-#     f2.close()
-#     assertFalse(f2)
-#
-#
+
+
+def test_exc_missingfile(setup_teardown_file):
+    """ KeyError raised when attempting to open missing file """
+    f = setup_teardown_file[3]
+    f['ext'] = ExternalLink('mongoose.exdir','/foo')
+    with pytest.raises(RuntimeError):
+        f['ext']
+
+
+def test_close_file(setup_teardown_file):
+    """ Files opened by accessing external links can be closed
+    """
+    external_path = setup_teardown_file[0] / 'foo.exdir'
+    f = setup_teardown_file[3]
+    g = File(external_path, 'w')
+    f['ext'] = ExternalLink(external_path, '/')
+    grp = f['ext']
+    f2 = grp.file
+    f2.close()
+    assert not f2
+
+# TODO uncomment if we start accepting unicode names
 # def test_unicode_encode(setup_teardown_file):
 #     """
 #     Check that external links encode unicode filenames properly
-#     Testing issue #732
 #     """
-#     ext_filename = os.path.join(mkdtemp(), u"α.exdir")
-#     with File(ext_filename, "w") as ext_file:
+#     external_path = setup_teardown_file[0] / u"α.exdir"
+#     with File(external_path, "w") as ext_file:
 #         ext_file.create_group('external')
-#     f['ext'] = ExternalLink(ext_filename, '/external')
+#     f['ext'] = ExternalLink(external_path, '/external')
 #
 #
 # def test_unicode_decode(setup_teardown_file):
 #     """
 #     Check that external links decode unicode filenames properly
-#     Testing issue #732
 #     """
-#     ext_filename = os.path.join(mkdtemp(), u"α.exdir")
-#     with File(ext_filename, "w") as ext_file:
+#     external_path = setup_teardown_file[0] / u"α.exdir"
+#     with File(external_path, "w") as ext_file:
 #         ext_file.create_group('external')
 #         ext_file["external"].attrs["ext_attr"] = "test"
-#     f['ext'] = ExternalLink(ext_filename, '/external')
-#     assertEqual(f["ext"].attrs["ext_attr"], "test")
+#     f['ext'] = ExternalLink(external_path, '/external')
+#     assert f["ext"].attrs["ext_attr"] == "test"
 #
 #
 # def test_unicode_exdir_path(setup_teardown_file):
 #     """
 #     Check that external links handle unicode exdir paths properly
-#     Testing issue #333
 #     """
-#     ext_filename = os.path.join(mkdtemp(), "external.exdir")
-#     with File(ext_filename, "w") as ext_file:
+#     external_path = setup_teardown_file[0] / u"external.exdir"
+#     with File(external_path, "w") as ext_file:
 #         ext_file.create_group(u'α')
 #         ext_file[u"α"].attrs["ext_attr"] = "test"
-#     f['ext'] = ExternalLink(ext_filename, u'/α')
+#     f['ext'] = ExternalLink(external_path, u'/α')
 #     assertEqual(f["ext"].attrs["ext_attr"], "test")

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -44,11 +44,11 @@ def test_external_links(setup_teardown_file):
 def test_get_link(setup_teardown_file):
     """ Get link values """
     f = setup_teardown_file[3]
-    g = File(setup_teardown_file[0] / 'mongoose.exdir')
+    g = File(setup_teardown_file[0] / 'somewhere.exdir')
     f.create_group('mongoose')
     g.create_group('mongoose')
     sl = SoftLink('/mongoose')
-    el = ExternalLink('somewhere.hdf5', 'mongoose')
+    el = ExternalLink('somewhere.exdir', 'mongoose')
 
     f['soft'] = sl
     f['external'] = el
@@ -63,16 +63,16 @@ def test_get_link(setup_teardown_file):
 
 
 # Feature: Create and manage soft links with the high-level interface
-def test_spath(setup_teardown_file):
+def test_soft_path(setup_teardown_file):
     """ SoftLink directory attribute """
     sl = SoftLink('/foo')
     assert sl.path == '/foo'
 
 
-# def test_srepr(setup_teardown_file):
-#     """ SoftLink path repr """
-#     sl = SoftLink('/foo')
-#     assertIsInstance(repr(sl), six.string_types)
+def test_soft_repr(setup_teardown_file):
+    """ SoftLink path repr """
+    sl = SoftLink('/foo')
+    assert isinstance(repr(sl), str)
 
 
 def test_linked_group_equal(setup_teardown_file):
@@ -91,39 +91,56 @@ def test_exc(setup_teardown_file):
     f['alias'] = SoftLink('new')
     with pytest.raises(KeyError):
         f['alias']
-#
-#
-# # Feature: Create and manage external links
-# def test_epath(setup_teardown_file):
-#     """ External link paths attributes """
-#     el = ExternalLink('foo.hdf5', '/foo')
-#     assertEqual(el.filename, 'foo.hdf5')
-#     assertEqual(el.path, '/foo')
-#
-# def test_erepr(setup_teardown_file):
-#     """ External link repr """
-#     el = ExternalLink('foo.hdf5','/foo')
-#     assertIsInstance(repr(el), six.string_types)
-#
-# def test_create(setup_teardown_file):
-#     """ Creating external links """
-#     f['ext'] = ExternalLink(ename, '/external')
-#     grp = f['ext']
-#     ef = grp.file
-#     assertNotEqual(ef, f)
-#     assertEqual(grp.name, '/external')
-#
-# def test_exc(setup_teardown_file):
-#     """ KeyError raised when attempting to open broken link """
-#     f['ext'] = ExternalLink(ename, '/missing')
-#     with assertRaises(KeyError):
-#         f['ext']
+
+
+# Feature: Create and manage external links
+def test_external_path(setup_teardown_file):
+    """ External link paths attributes """
+    g = File(setup_teardown_file[0] / 'foo.exdir', 'w')
+    egrp = g.create_group('foo')
+    el = ExternalLink(setup_teardown_file[0] / 'foo.exdir', '/foo')
+    assert el.filename == 'foo.exdir'
+    assert el.path == '/foo'
+
+
+def test_external_must_exist(setup_teardown_file):
+    """ External link paths attributes """
+    with pytest.raises(FileExistsError):
+        el = ExternalLink('foo.exdir', '/foo')
+
+
+def test_external_repr(setup_teardown_file):
+    """ External link repr """
+    g = File(setup_teardown_file[0] / 'foo.exdir', 'w')
+    el = ExternalLink(setup_teardown_file[0] / 'foo.exdir', '/foo')
+    assert isinstance(repr(el), str)
+
+
+def test_create(setup_teardown_file):
+    """ Creating external links """
+    f = setup_teardown_file[3]
+    g = File(setup_teardown_file[0] / 'foo.exdir', 'w')
+    egrp = g.require_group('external')
+    f['ext'] = ExternalLink(setup_teardown_file[0] / 'foo.exdir', '/external')
+    grp = f['ext']
+    ef = grp.file
+    assert ef != f
+    assert grp.name == '/external'
+
+
+def test_broken_external_link(setup_teardown_file):
+    """ KeyError raised when attempting to open broken link """
+    f = setup_teardown_file[3]
+    g = File(setup_teardown_file[0] / 'foo.exdir', 'w')
+    f['ext'] = ExternalLink(setup_teardown_file[0] / 'foo.exdir', '/missing')
+    with pytest.raises(KeyError):
+        f['ext']
 #
 # # I would prefer IOError but there's no way to fix this as the exception
 # # class is determined by HDF5.
 # def test_exc_missingfile(setup_teardown_file):
 #     """ KeyError raised when attempting to open missing file """
-#     f['ext'] = ExternalLink('mongoose.hdf5','/foo')
+#     f['ext'] = ExternalLink('mongoose.exdir','/foo')
 #     with assertRaises(KeyError):
 #         f['ext']
 #
@@ -143,7 +160,7 @@ def test_exc(setup_teardown_file):
 #     Check that external links encode unicode filenames properly
 #     Testing issue #732
 #     """
-#     ext_filename = os.path.join(mkdtemp(), u"α.hdf5")
+#     ext_filename = os.path.join(mkdtemp(), u"α.exdir")
 #     with File(ext_filename, "w") as ext_file:
 #         ext_file.create_group('external')
 #     f['ext'] = ExternalLink(ext_filename, '/external')
@@ -154,7 +171,7 @@ def test_exc(setup_teardown_file):
 #     Check that external links decode unicode filenames properly
 #     Testing issue #732
 #     """
-#     ext_filename = os.path.join(mkdtemp(), u"α.hdf5")
+#     ext_filename = os.path.join(mkdtemp(), u"α.exdir")
 #     with File(ext_filename, "w") as ext_file:
 #         ext_file.create_group('external')
 #         ext_file["external"].attrs["ext_attr"] = "test"
@@ -162,12 +179,12 @@ def test_exc(setup_teardown_file):
 #     assertEqual(f["ext"].attrs["ext_attr"], "test")
 #
 #
-# def test_unicode_hdf5_path(setup_teardown_file):
+# def test_unicode_exdir_path(setup_teardown_file):
 #     """
-#     Check that external links handle unicode hdf5 paths properly
+#     Check that external links handle unicode exdir paths properly
 #     Testing issue #333
 #     """
-#     ext_filename = os.path.join(mkdtemp(), "external.hdf5")
+#     ext_filename = os.path.join(mkdtemp(), "external.exdir")
 #     with File(ext_filename, "w") as ext_file:
 #         ext_file.create_group(u'α')
 #         ext_file[u"α"].attrs["ext_attr"] = "test"

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Exdir, the Experimental Directory Structure.
+#
+# Copyright 2019 Mikkel Lepperød
+#
+# License: MIT, see "LICENSE" file for the full license terms.
+#
+# This file contains code from h5py, a Python interface to the HDF5 library,
+# licensed under a standard 3-clause BSD license
+# with copyright Andrew Collette and contributors.
+# See http://www.h5py.org and the "3rdparty/h5py-LICENSE" file for details.
+
+import exdir
+import pytest
+import numpy as np
+try:
+    import ruamel_yaml as yaml
+except ImportError:
+    import ruamel.yaml as yaml
+
+
+def test_softlinks(setup_teardown_file):
+    """ Broken softlinks are contained, but their members are not """
+    f = setup_teardown_file[3]
+    g = exdir.File(setup_teardown_file[2] / 'mongoose.exdir')
+    f.create_group('mongoose')
+    g.create_group('mongoose')
+    f.create_group('grp')
+    f['/grp/soft'] = exdir.SoftLink('/mongoose')
+    f['/grp/external'] = exdir.ExternalLink('mongoose.exdir', '/mongoose')
+    assert '/grp/soft' in f
+    assert '/grp/soft/something' not in f
+    assert '/grp/external' in f
+    assert '/grp/external/something' not in f
+
+
+# def test_get_link(setup_teardown_file):
+#     """ Get link values """
+#     f = setup_teardown_file[3]
+#     g = exdir.File(setup_teardown_file[0] / 'mongoose.exdir')
+#     f.create_group('mongoose')
+#     g.create_group('mongoose')
+#     sl = SoftLink('/mongoose')
+#     el = ExternalLink('somewhere.hdf5', 'mongoose')
+#
+#     f['soft'] = sl
+#     f['external'] = el
+#
+#     out_sl = f.get('soft', getlink=True)
+#     out_el = f.get('external', getlink=True)
+#
+#     #TODO: redo with SoftLink/ExternalLink built-in equality
+#     assertIsInstance(out_sl, SoftLink)
+#     assert out_sl == sl
+#     assertIsInstance(out_el, ExternalLink)
+#     assert out_el == el
+#
+#
+# Feature: Create and manage soft links with the high-level interface
+def test_spath(setup_teardown_file):
+    """ SoftLink directory attribute """
+    sl = exdir.SoftLink('/foo')
+    assert sl.path == '/foo'
+
+
+# def test_srepr(setup_teardown_file):
+#     """ SoftLink path repr """
+#     sl = SoftLink('/foo')
+#     assertIsInstance(repr(sl), six.string_types)
+
+
+def test_create(setup_teardown_file):
+    """ Create new soft link by assignment """
+    f = setup_teardown_file[3]
+    g = f.create_group('new')
+    sl = exdir.SoftLink('/new')
+    f['alias'] = sl
+    g2 = f['alias']
+    assert g == g2
+
+
+def test_exc(setup_teardown_file):
+    """ Opening dangling soft link results in KeyError """
+    f = setup_teardown_file[3]
+    f['alias'] = exdir.SoftLink('new')
+    with pytest.raises(KeyError):
+        f['alias']
+#
+#
+# # Feature: Create and manage external links
+# def test_epath(setup_teardown_file):
+#     """ External link paths attributes """
+#     el = ExternalLink('foo.hdf5', '/foo')
+#     assertEqual(el.filename, 'foo.hdf5')
+#     assertEqual(el.path, '/foo')
+#
+# def test_erepr(setup_teardown_file):
+#     """ External link repr """
+#     el = ExternalLink('foo.hdf5','/foo')
+#     assertIsInstance(repr(el), six.string_types)
+#
+# def test_create(setup_teardown_file):
+#     """ Creating external links """
+#     f['ext'] = ExternalLink(ename, '/external')
+#     grp = f['ext']
+#     ef = grp.file
+#     assertNotEqual(ef, f)
+#     assertEqual(grp.name, '/external')
+#
+# def test_exc(setup_teardown_file):
+#     """ KeyError raised when attempting to open broken link """
+#     f['ext'] = ExternalLink(ename, '/missing')
+#     with assertRaises(KeyError):
+#         f['ext']
+#
+# # I would prefer IOError but there's no way to fix this as the exception
+# # class is determined by HDF5.
+# def test_exc_missingfile(setup_teardown_file):
+#     """ KeyError raised when attempting to open missing file """
+#     f['ext'] = ExternalLink('mongoose.hdf5','/foo')
+#     with assertRaises(KeyError):
+#         f['ext']
+#
+# def test_close_file(setup_teardown_file):
+#     """ Files opened by accessing external links can be closed
+#     Issue 189.
+#     """
+#     f['ext'] = ExternalLink(ename, '/')
+#     grp = f['ext']
+#     f2 = grp.file
+#     f2.close()
+#     assertFalse(f2)
+#
+#
+# def test_unicode_encode(setup_teardown_file):
+#     """
+#     Check that external links encode unicode filenames properly
+#     Testing issue #732
+#     """
+#     ext_filename = os.path.join(mkdtemp(), u"α.hdf5")
+#     with File(ext_filename, "w") as ext_file:
+#         ext_file.create_group('external')
+#     f['ext'] = ExternalLink(ext_filename, '/external')
+#
+#
+# def test_unicode_decode(setup_teardown_file):
+#     """
+#     Check that external links decode unicode filenames properly
+#     Testing issue #732
+#     """
+#     ext_filename = os.path.join(mkdtemp(), u"α.hdf5")
+#     with File(ext_filename, "w") as ext_file:
+#         ext_file.create_group('external')
+#         ext_file["external"].attrs["ext_attr"] = "test"
+#     f['ext'] = ExternalLink(ext_filename, '/external')
+#     assertEqual(f["ext"].attrs["ext_attr"], "test")
+#
+#
+# def test_unicode_hdf5_path(setup_teardown_file):
+#     """
+#     Check that external links handle unicode hdf5 paths properly
+#     Testing issue #333
+#     """
+#     ext_filename = os.path.join(mkdtemp(), "external.hdf5")
+#     with File(ext_filename, "w") as ext_file:
+#         ext_file.create_group(u'α')
+#         ext_file[u"α"].attrs["ext_attr"] = "test"
+#     f['ext'] = ExternalLink(ext_filename, u'/α')
+#     assertEqual(f["ext"].attrs["ext_attr"], "test")


### PR DESCRIPTION
To extend our support for data structures and variable length strings, storage with feather which support saving pandas DataFrames has been implemented.

* Storing with feather is invoked when a DataFrame is presented to the API
* All previous functionality still works where everything that is not a DataFrame invokes regular behavior with numpy memmaps.