### PR TITLE
Convert deprecated ruamel.yaml function calls to method calls

### DIFF
--- a/exdir/core/attribute.py
+++ b/exdir/core/attribute.py
@@ -166,12 +166,9 @@ class Attribute(object):
             attribute_data_quoted = attrs
 
         with self.filename.open("w", encoding="utf-8") as attribute_file:
-            yaml.dump(
+            yaml.YAML(typ="rt", pure=True).dump(
                 attribute_data_quoted,
                 attribute_file,
-                default_flow_style=False,
-                allow_unicode=True,
-                Dumper=yaml.RoundTripDumper
             )
 
     # TODO only needs filename, make into free function

--- a/exdir/core/attribute.py
+++ b/exdir/core/attribute.py
@@ -180,7 +180,7 @@ class Attribute(object):
         attrs = {}
         if self.filename.exists():  # NOTE str for Python 3.5 support
             with self.filename.open("r", encoding="utf-8") as meta_file:
-                attrs = yaml.safe_load(meta_file)
+                attrs = yaml.YAML(typ="safe", pure=True).load(meta_file)
         return attrs
 
     def __iter__(self):

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -103,7 +103,7 @@ def is_nonraw_object_directory(directory):
     if not meta_filename.exists():
         return False
     with meta_filename.open("r", encoding="utf-8") as meta_file:
-        meta_data = yaml.safe_load(meta_file)
+        meta_data = yaml.YAML(typ="safe", pure=True).load(meta_file)
 
         if not isinstance(meta_data, dict):
             return False
@@ -140,7 +140,7 @@ def root_directory(path):
 
         meta_filename = path / META_FILENAME
         with meta_filename.open("r", encoding="utf-8") as meta_file:
-            meta_data = yaml.safe_load(meta_file)
+            meta_data = yaml.YAML(typ="safe", pure=True).load(meta_file)
         if EXDIR_METANAME not in meta_data:
             path = path.parent
             continue

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -62,7 +62,10 @@ def _create_object_directory(directory, metadata):
                 version=1
             )
         else:
-            metadata_string = yaml.dump(metadata)
+            from io import StringIO
+            with StringIO() as buf:
+                yaml.YAML(typ="safe", pure=True).dump(metadata, buf)
+                metadata_string = buf.getvalue()
 
         try:
             meta_file.write(metadata_string)

--- a/exdir/core/group.py
+++ b/exdir/core/group.py
@@ -402,7 +402,7 @@ class Group(Object):
 
         meta_filename = directory / exob.META_FILENAME
         with meta_filename.open("r", encoding="utf-8") as meta_file:
-            meta_data = yaml.safe_load(meta_file)
+            meta_data = yaml.YAML(typ="safe", pure=True).load(meta_file)
         if meta_data[exob.EXDIR_METANAME][exob.TYPE_METANAME] == exob.DATASET_TYPENAME:
             return self._dataset(name)
         elif meta_data[exob.EXDIR_METANAME][exob.TYPE_METANAME] == exob.GROUP_TYPENAME:

--- a/tests/test_help_functions.py
+++ b/tests/test_help_functions.py
@@ -141,10 +141,9 @@ def test_is_nonraw_object_directory(setup_teardown_folder):
             exob.EXDIR_METANAME: {
                 exob.VERSION_METANAME: 1}
         }
-        yaml.safe_dump(metadata,
-                       meta_file,
-                       default_flow_style=False,
-                       allow_unicode=True)
+        yaml.YAML(typ="safe", pure=True).dump(
+            metadata,
+            meta_file)
 
     result = exob.is_nonraw_object_directory(setup_teardown_folder[2])
     assert result is False
@@ -156,10 +155,9 @@ def test_is_nonraw_object_directory(setup_teardown_folder):
                 exob.TYPE_METANAME: "wrong_typename",
                 exob.VERSION_METANAME: 1}
         }
-        yaml.safe_dump(metadata,
-                       meta_file,
-                       default_flow_style=False,
-                       allow_unicode=True)
+        yaml.YAML(typ="safe", pure=True).dump(
+            metadata,
+            meta_file)
 
     result = exob.is_nonraw_object_directory(setup_teardown_folder[2])
     assert result is False
@@ -171,10 +169,9 @@ def test_is_nonraw_object_directory(setup_teardown_folder):
                 exob.TYPE_METANAME: exob.DATASET_TYPENAME,
                 exob.VERSION_METANAME: 1}
         }
-        yaml.safe_dump(metadata,
-                       meta_file,
-                       default_flow_style=False,
-                       allow_unicode=True)
+        yaml.YAML(typ="safe", pure=True).dump(
+            metadata,
+            meta_file)
 
     result = exob.is_nonraw_object_directory(setup_teardown_folder[2])
     assert result is True

--- a/tests/test_help_functions.py
+++ b/tests/test_help_functions.py
@@ -114,7 +114,7 @@ def test_create_object_directory(setup_teardown_folder):
     }
 
     with file_path.open("r", encoding="utf-8") as meta_file:
-        metadata = yaml.safe_load(meta_file)
+        metadata = yaml.YAML(typ="safe", pure=True).load(meta_file)
 
         assert metadata == compare_metadata
 

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -60,7 +60,7 @@ def test_object_attrs(setup_teardown_file):
     obj.attrs = "test value"
 
     with (setup_teardown_file[1] / "test_object" / ATTRIBUTES_FILENAME).open("r", encoding="utf-8") as meta_file:
-        meta_data = yaml.safe_load(meta_file)
+        meta_data = yaml.YAML(typ="safe", pure=True).load(meta_file)
         assert meta_data == "test value"
 
 


### PR DESCRIPTION
The version changelog is at https://yaml.readthedocs.io/en/latest/api.html#departure-from-previous-api.  This gets rid of all the warnings under pytest when using ruamel.yaml 0.17.21.