### PR TITLE
Remove support for Python 3.8, introduce 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -30,4 +30,4 @@ jobs:
         python setup.py install
     - name: Test with pytest
       run: |
-        pytest
+        python -m pytest

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     ],
     install_requires=[
         "numpy>=1.20",
-        "ruamel.yaml>=0.16",
+        "ruamel.yaml==0.17.21",
         "six>=1.15",
     ],
     zip_safe=False,


### PR DESCRIPTION
The latest versions of NumPy dropped support for Python 3.8. Exdir follows the support matrix of NumPy to avoid being stuck on an old version of NumPy.