### PR TITLE
Remove Python 2 leftovers

### DIFF
--- a/exdir/core/attribute.py
+++ b/exdir/core/attribute.py
@@ -1,6 +1,4 @@
 from enum import Enum
-import os
-import numpy as np
 import exdir
 try:
     import ruamel_yaml as yaml
@@ -23,7 +21,7 @@ def _quote_strings(value):
     return value
 
 
-class Attribute(object):
+class Attribute:
     """
     The attribute object is a dictionary-like object that is used to access
     the attributes stored in the :code:`attributes.yaml` file for a given

--- a/exdir/core/exdir_file.py
+++ b/exdir/core/exdir_file.py
@@ -75,7 +75,7 @@ class File(Group):
         if directory.suffix != ".exdir":
             directory = directory.with_suffix(directory.suffix + ".exdir")
         self.user_mode = mode = mode or 'a'
-        recognized_modes = ['a', 'r', 'r+', 'w', 'w-', 'x', 'a']
+        recognized_modes = ['a', 'r', 'r+', 'w', 'w-', 'x']
         if mode not in recognized_modes:
             raise ValueError(
                 "IO mode {} not recognized, "

--- a/exdir/core/exdir_file.py
+++ b/exdir/core/exdir_file.py
@@ -115,7 +115,7 @@ class File(Group):
         else:
             self.io_mode = OpenMode.READ_WRITE
 
-        super(File, self).__init__(
+        super().__init__(
             root_directory=directory,
             parent_path=pathlib.PurePosixPath(""),
             object_name="",
@@ -197,7 +197,7 @@ class File(Group):
         """
         path = utils.path.remove_root(name)
 
-        return super(File, self).create_group(path)
+        return super().create_group(path)
 
     def require_group(self, name):
         """
@@ -212,17 +212,17 @@ class File(Group):
         """
         path = utils.path.remove_root(name)
 
-        return super(File, self).require_group(path)
+        return super().require_group(path)
 
     def __getitem__(self, name):
         path = utils.path.remove_root(name)
         if len(path.parts) < 1:
             return self
-        return super(File, self).__getitem__(path)
+        return super().__getitem__(path)
 
     def __contains__(self, name):
         path = utils.path.remove_root(name)
-        return super(File, self).__contains__(path)
+        return super().__contains__(path)
 
     def __repr__(self):
         if self.io_mode == OpenMode.FILE_CLOSED:

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -12,6 +12,7 @@ from .attribute import Attribute
 from .constants import *
 from .mode import assert_file_open, OpenMode
 
+
 def _resolve_path(path):
     return Path(path).resolve()
 

--- a/exdir/core/exdir_object.py
+++ b/exdir/core/exdir_object.py
@@ -1,18 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import with_metaclass
-
-from enum import Enum
-import os
-import warnings
+from pathlib import Path
 import shutil
-try:
-    import pathlib
-except ImportError as e:
-    try:
-        import pathlib2 as pathlib
-    except ImportError:
-        raise e
+
 try:
     import ruamel_yaml as yaml
 except ImportError:
@@ -20,13 +8,12 @@ except ImportError:
 
 import exdir
 
-from .. import utils
 from .attribute import Attribute
 from .constants import *
 from .mode import assert_file_open, OpenMode
 
 def _resolve_path(path):
-    return pathlib.Path(path).resolve()
+    return Path(path).resolve()
 
 
 def _assert_valid_name(name, container):
@@ -185,7 +172,7 @@ def open_object(path):
 # NOTE This is in a separate file only because of circular imports between Object and Raw otherwise
 # TODO move this back to Object once circular imports are figured out
 
-class Object(object):
+class Object:
     """
     Parent class for exdir Group and exdir dataset objects
     """

--- a/exdir/core/mode.py
+++ b/exdir/core/mode.py
@@ -1,10 +1,10 @@
-from enum import Enum
+from enum import Enum, auto
 
 
 class OpenMode(Enum):
-    READ_WRITE = 1
-    READ_ONLY = 2
-    FILE_CLOSED = 3
+    READ_WRITE = auto()
+    READ_ONLY = auto()
+    FILE_CLOSED = auto()
 
 
 def assert_file_open(file_object):

--- a/exdir/utils/path.py
+++ b/exdir/utils/path.py
@@ -1,10 +1,4 @@
-try:
-    import pathlib
-except ImportError as e:
-    try:
-        import pathlib2 as pathlib
-    except ImportError:
-        raise e
+import pathlib
 
 
 def name_to_asserted_group_path(name):

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -303,7 +303,7 @@ def test_open_two_attrs(setup_teardown_file):
     f = setup_teardown_file[3]
 
     f.attrs['can_overwrite'] = 42
-    f.attrs['another_atribute'] = 14
+    f.attrs['another_attribute'] = 14
 
 
 def test_exc(setup_teardown_file):

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -329,12 +329,12 @@ def test_close_group(setup_teardown_file):
     assert 'dataset' not in f
 
     # unable to create new stuff
-    match = "Unable to operate on closed File instance."
-    with pytest.raises(IOError, match=match):
+    mtch = "Unable to operate on closed File instance."
+    with pytest.raises(IOError, match=mtch):
         f.create_group("group")
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         grp.create_group("group")
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         grp.attrs = {'group': 'attrs'}
 
 
@@ -349,16 +349,16 @@ def test_close_attrs(setup_teardown_file):
     file_attrs = f.attrs
     f.close()
 
-    match = "Unable to operate on closed File instance."
-    with pytest.raises(IOError, match=match):
+    mtch = "Unable to operate on closed File instance."
+    with pytest.raises(IOError, match=mtch):
         f.attrs = {'file': 'attrs'}
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         file_attrs['new'] = 'yo'
 
     # unable to retrieve stuff
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         file_attrs['file']
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         f.attrs
     assert 'file' not in file_attrs
 
@@ -373,12 +373,12 @@ def test_close_raw(setup_teardown_file):
     assert "raw" not in f
 
     # unable to create new stuff
-    match = "Unable to operate on closed File instance."
-    with pytest.raises(IOError, match=match):
+    mtch = "Unable to operate on closed File instance."
+    with pytest.raises(IOError, match=mtch):
         f.create_raw('raw')
 
     # unable to retrieve
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         f['raw']
 
 
@@ -396,25 +396,25 @@ def test_close_dataset(setup_teardown_file):
     assert 'dataset' not in f
 
     # unable to create new stuff
-    match = "Unable to operate on closed File instance."
+    mtch = "Unable to operate on closed File instance."
 
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         f.create_dataset('dataset', data=np.array([1,2,3]))
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         grp.create_dataset('dataset', data=np.array([1,2,3]))
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         dset.attrs = {'dataset': 'attrs'}
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         dset_attrs['new'] = 'yo'
 
     # unable to retrieve stuff
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         dset.data
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         dset.shape
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         dset.dtype
-    with pytest.raises(IOError, match=match):
+    with pytest.raises(IOError, match=mtch):
         dset.attrs
 
     assert 'dataset' not in dset_attrs

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -313,7 +313,7 @@ def test_contains(setup_teardown_file):
     assert not "c" in grp
 
     with pytest.raises(NotImplementedError):
-        assert "/b" in  grp
+        assert "/b" in grp
 
 
 def test_contains_deep(setup_teardown_file):

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -220,8 +220,8 @@ def test_nonexisting(setup_teardown_file):
     """Deleting non-existent object raises KeyError."""
     f = setup_teardown_file[3]
     grp = f.create_group("test")
-    match = "No such object: 'foo' in path *"
-    with pytest.raises(KeyError, match=match):
+    mtch = "No such object: 'foo' in path *"
+    with pytest.raises(KeyError, match=mtch):
         del grp["foo"]
 
 
@@ -231,8 +231,8 @@ def test_readonly_delete_exception(setup_teardown_file):
     f.close()
 
     f = File(setup_teardown_file[1], "r")
-    match = "Cannot change data on file in read only 'r' mode"
-    with pytest.raises(IOError, match=match):
+    mtch = "Cannot change data on file in read only 'r' mode"
+    with pytest.raises(IOError, match=mtch):
         del f["foo"]
 
 
@@ -248,8 +248,8 @@ def test_delete_dataset(setup_teardown_file):
     del foo
     assert 'foo' in grp
     del grp['foo']
-    match = "No such object: 'foo' in path *"
-    with pytest.raises(KeyError, match=match):
+    mtch = "No such object: 'foo' in path *"
+    with pytest.raises(KeyError, match=mtch):
         grp['foo']
     # the "bar" dataset is intact
     assert isinstance(grp['bar'], Dataset)
@@ -296,8 +296,8 @@ def test_open_deep(setup_teardown_file):
 def test_nonexistent(setup_teardown_file):
     """Opening missing objects raises KeyError."""
     f = setup_teardown_file[3]
-    match = "No such object: 'foo' in path *"
-    with pytest.raises(KeyError, match=match):
+    mtch = "No such object: 'foo' in path *"
+    with pytest.raises(KeyError, match=mtch):
         f["foo"]
 
 

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -445,7 +445,7 @@ def test_eq(setup_teardown_file):
 
 
 # Feature: Parent
-def test_eq(setup_teardown_file):
+def test_eq_parent(setup_teardown_file):
     """Test equal."""
     f = setup_teardown_file[3]
     grp = f.create_group("test")

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -80,6 +80,7 @@ def test_object_directory(setup_teardown_file):
     assert obj.attributes_filename == setup_teardown_file[1] / "test_object" / ATTRIBUTES_FILENAME
     assert obj.meta_filename == setup_teardown_file[1] / "test_object" / META_FILENAME
 
+
 def test_object_create_raw(setup_teardown_file):
     obj = setup_teardown_file[3].create_dataset("test_object", shape=(1,), dtype=float)
     obj.create_raw("test_raw")

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -34,7 +34,7 @@ def test_create_raw(setup_teardown_file):
 
 
 def test_require_raw(setup_teardown_file):
-    """Raw is created if it doesn"t exist."""
+    """Raw is created if it doesn't exist."""
 
     f = setup_teardown_file[3]
     grp = f.create_group("test")


### PR DESCRIPTION
Inheriting from `object` isn't necessary anymore and neither is passing arguments to `super`.

There were also a bunch of unused imports.