### PR TITLE
Update reserved paths based on Python 3.13 Windows changes

### DIFF
--- a/tests/test_help_functions.py
+++ b/tests/test_help_functions.py
@@ -33,7 +33,8 @@ def test_assert_valid_name_minimal(setup_teardown_folder):
 
     exob._assert_valid_name("A", f)
 
-    exob._assert_valid_name("\n", f)
+    with pytest.raises(NameError):
+        exob._assert_valid_name("\n", f)
 
     exob._assert_valid_name(six.unichr(0x4500), f)
 


### PR DESCRIPTION
Closes https://github.com/CINPLA/exdir/issues/180

I will update the Python versions tested in CI separately, but this is passing using Tox with versions 3.7-3.13.