### PR TITLE
Bump numpy from 1.26.4 to 2.0.0

### DIFF
--- a/exdir/core/dataset.py
+++ b/exdir/core/dataset.py
@@ -132,12 +132,7 @@ class Dataset(exob.Object):
             shape=value.shape
         )
 
-        if len(value.shape) == 0:
-            # scalars need to be set with itemset
-            self._data_memmap.itemset(value)
-        else:
-            # replace the contents with the value
-            self._data_memmap[:] = value
+        self._data_memmap[...] = value
 
         # update attributes and plugin metadata
         if attrs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ h5py==3.11.0
     # via -r requirements.in
 iniconfig==1.1.1
     # via pytest
-numpy==1.26.4
+numpy==2.0.0
     # via
     #   -r requirements.in
     #   h5py


### PR DESCRIPTION
This is https://github.com/CINPLA/exdir/pull/186 but includes the fix for NumPy 2.0.  It also works with the version of NumPy (1.21.6) I'm using with Python 3.7.