### PR TITLE
Request dependabot to group all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
+  groups:
+    all:
+      patterns:
+        - "*"


### PR DESCRIPTION
This should keep dependabot from making a single pull request for each package it is trying update.