### PR TITLE
Use iter() to check if object is iterable

### DIFF
--- a/exdir/plugin_interface/plugin_interface.py
+++ b/exdir/plugin_interface/plugin_interface.py
@@ -281,7 +281,7 @@ class Manager:
 
         # make iterable if not already so
         try:
-            _ = (e for e in plugins)
+            iter(plugins)
         except TypeError:
             plugins = [plugins]
 


### PR DESCRIPTION
With Python 3.14 TypeError will only be thrown when the generator
expression is executed.
